### PR TITLE
[FEAT, TEST] 테스트 API 구현

### DIFF
--- a/src/main/java/dnd/donworry/controller/TestController.java
+++ b/src/main/java/dnd/donworry/controller/TestController.java
@@ -1,26 +1,41 @@
 package dnd.donworry.controller;
 
-import dnd.donworry.domain.constants.ResponseCode;
-import dnd.donworry.domain.dto.test.TestResponseDto;
-import dnd.donworry.service.TestService;
-import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import dnd.donworry.domain.constants.ResponseCode;
+import dnd.donworry.domain.dto.test.TestRequestDto;
+import dnd.donworry.domain.dto.test.TestResponseDto;
+import dnd.donworry.service.TestService;
+import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/api/v1/test")
 @RequiredArgsConstructor
 public class TestController {
 
-    private final TestService testService;
+	private final TestService testService;
 
-    @PostMapping("/save")
-    public ResponseEntity<?> save(@RequestBody TestResponseDto testResponseDto) {
-        String username = "test"; // Authentication.getName()으로 변경
-        testService.saveAfterSignup(username, testResponseDto);
-        return ResponseCode.TEST_CREATED.toResponse(null);
-    }
+	@PostMapping("/background")
+	public ResponseEntity<?> save(@RequestBody TestResponseDto testResponseDto) {
+		String username = "test"; // Authentication.getName()으로 변경
+		testService.save(username, testResponseDto);
+		return ResponseCode.TEST_SAVED.toResponse(null);
+	}
+
+	@PostMapping
+	public ResponseEntity<?> makeResult(@RequestBody TestRequestDto testRequestDto) {
+		String username = "test"; // Authentication.getName()으로 변경
+		return ResponseCode.TEST_SUCCESS.toResponse(testService.makeResult(username, testRequestDto));
+	}
+
+	@GetMapping("/result/{resultId}")
+	public ResponseEntity<?> findResult(@PathVariable Long resultId) {
+		return ResponseCode.TEST_SUCCESS.toResponse(testService.findResult(resultId));
+	}
 }

--- a/src/main/java/dnd/donworry/controller/TestController.java
+++ b/src/main/java/dnd/donworry/controller/TestController.java
@@ -1,6 +1,5 @@
 package dnd.donworry.controller;
 
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -8,34 +7,83 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import dnd.donworry.domain.constants.ResResult;
 import dnd.donworry.domain.constants.ResponseCode;
 import dnd.donworry.domain.dto.test.TestRequestDto;
 import dnd.donworry.domain.dto.test.TestResponseDto;
 import dnd.donworry.service.TestService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/api/v1/test")
 @RequiredArgsConstructor
+@Tag(name = "테스트 API", description = "테스트 결과를 생성하고 조회합니다.")
 public class TestController {
 
 	private final TestService testService;
 
 	@PostMapping("/background")
-	public ResponseEntity<?> save(@RequestBody TestResponseDto testResponseDto) {
+	@Operation(summary = "백그라운드 테스트 결과 저장", description = "비회원이 테스트 후 회원가입을 진행할 시 백그라운드로 테스트 결과를 저장합니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "테스트 결과 저장 성공", content = @Content(
+			mediaType = "application/json",
+			examples = @ExampleObject(value = "{\n  \"code\": \"200\", \n \"message\": \"테스트 결과 저장에 성공했습니다.\"\n}"))),
+		@ApiResponse(responseCode = "400", description = "테스트 결과 저장 실패", content = @Content(
+			mediaType = "application/json",
+			examples = @ExampleObject(value = "{\n  \"code\": \"400\", \n \"message\": \"테스트 결과 저장에 실패했습니다.\"\n}"))),
+		@ApiResponse(responseCode = "500", description = "서버 에러", content = @Content(
+			mediaType = "application/json",
+			examples = @ExampleObject(value = "{\n  \"code\": \"500\", \n \"message\": \"서버에 에러가 발생했습니다.\"\n}")))
+	})
+	public ResResult<?> save(@RequestBody TestResponseDto testResponseDto) {
 		String username = "test"; // Authentication.getName()으로 변경
 		testService.save(username, testResponseDto);
-		return ResponseCode.TEST_SAVED.toResponse(null);
+		return ResponseCode.TEST_SUCCESS.toResponse(null);
 	}
 
 	@PostMapping
-	public ResponseEntity<?> makeResult(@RequestBody TestRequestDto testRequestDto) {
+	@Operation(summary = "테스트 결과 생성", description = "일반적인 테스트 진행 후 결과를 생성합니다. 비회원인 경우 백그라운드에 저장되며 회원가입 시 저장된 결과를 불러옵니다. 회원인 경우에는 바로 결과가 저장됩니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "테스트 결과 생성 성공"),
+		@ApiResponse(responseCode = "400", description = "테스트 결과 생성 실패", content = @Content(
+			mediaType = "application/json",
+			examples = @ExampleObject(value = "{\n  \"code\": \"400\", \n \"message\": \"테스트 결과 조회에 실패했습니다.\"\n}"))),
+		@ApiResponse(responseCode = "500", description = "서버 에러", content = @Content(
+			mediaType = "application/json",
+			examples = @ExampleObject(value = "{\n  \"code\": \"500\", \n \"message\": \"서버에 에러가 발생했습니다.\"\n}")))
+	})
+	public ResResult<TestResponseDto> makeResult(@RequestBody TestRequestDto testRequestDto) {
 		String username = "test"; // Authentication.getName()으로 변경
 		return ResponseCode.TEST_SUCCESS.toResponse(testService.makeResult(username, testRequestDto));
 	}
 
 	@GetMapping("/result/{resultId}")
-	public ResponseEntity<?> findResult(@PathVariable Long resultId) {
+	@Operation(summary = "테스트 결과 조회", description = "테스트 결과를 조회합니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "테스트 결과 조회 성공"),
+		@ApiResponse(responseCode = "400", description = "테스트 결과 조회 실패", content = @Content(
+			mediaType = "application/json",
+			examples = @ExampleObject(value = "{\n  \"code\": \"400\", \n \"message\": \"테스트 결과 조회에 실패했습니다. \"\n}"))),
+		@ApiResponse(responseCode = "500", description = "서버 에러", content = @Content(
+			mediaType = "application/json",
+			examples = @ExampleObject(value = "{\n  \"code\": \"500\", \n \"message\": \"서버에 에러가 발생했습니다.\"\n}"))),
+		@ApiResponse(responseCode = "404", description = "테스트 결과 없음", content = @Content(
+			mediaType = "application/json",
+			examples = @ExampleObject(value = "{\n  \"code\": \"404\", \n \"message\": \"해당 테스트 결과가 존재하지 않습니다.\"\n}"))),
+		@ApiResponse(responseCode = "403", description = "접근 권한 없음", content = @Content(
+			mediaType = "application/json",
+			examples = @ExampleObject(value = "{\n  \"code\": \"403\", \n \"message\": \"접근 권한이 없습니다.\"\n}"))),
+		@ApiResponse(responseCode = "401", description = "토큰이 존재하지 않음", content = @Content(
+			mediaType = "application/json",
+			examples = @ExampleObject(value = "{\n  \"code\": \"401\", \n \"message\": \"토큰이 존재하지 않습니다.\"\n}")))
+	})
+	public ResResult<TestResponseDto> findResult(@PathVariable Long resultId) {
 		return ResponseCode.TEST_SUCCESS.toResponse(testService.findResult(resultId));
 	}
 }

--- a/src/main/java/dnd/donworry/domain/constants/ErrorCode.java
+++ b/src/main/java/dnd/donworry/domain/constants/ErrorCode.java
@@ -11,6 +11,9 @@ public enum ErrorCode {
 	/* COMMON */
 	NOT_AUTHORIZED_CONTENT("401", "접근 권한이 없습니다."),
 
+	/* TEST */
+	TEST_NOT_FOUND("404", "테스트 결과가 존재하지 않습니다."),
+
 	/* AUTH */
 	NO_JWT_TOKEN("401", "로그인 정보가 존재하지 않습니다. 다시 로그인해 주세요."),
 	NOT_AUTHORIZED_TOKEN("403", "접근 권한이 없습니다."),

--- a/src/main/java/dnd/donworry/domain/constants/ErrorCode.java
+++ b/src/main/java/dnd/donworry/domain/constants/ErrorCode.java
@@ -3,64 +3,60 @@ package dnd.donworry.domain.constants;
 import io.micrometer.common.lang.Nullable;
 import lombok.Getter;
 import lombok.ToString;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 
 @Getter
 @ToString
 public enum ErrorCode {
 
-    /* COMMON */
-    NOT_AUTHORIZED_CONTENT(HttpStatus.UNAUTHORIZED, "401", "접근 권한이 없습니다."),
+	/* COMMON */
+	NOT_AUTHORIZED_CONTENT("401", "접근 권한이 없습니다."),
 
-    /* AUTH */
-    NO_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "401", "로그인 정보가 존재하지 않습니다. 다시 로그인해 주세요."),
-    NOT_AUTHORIZED_TOKEN(HttpStatus.FORBIDDEN, "403", "접근 권한이 없습니다."),
-    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "401", "로그인 정보가 유효하지 않습니다."),
-    INVALID_TOKEN_TYPE(HttpStatus.UNAUTHORIZED, "401", "로그인 정보 형식이 올바르지 않습니다."),
-    INVALID_TOKEN_STRUCTURE(HttpStatus.UNAUTHORIZED, "401", "로그인 정보가 올바르지 않습니다."),
-    MODIFIED_TOKEN_DETECTED(HttpStatus.UNAUTHORIZED, "401", "로그인 정보가 변경되었습니다."),
-    EMAIL_VERIFICATION_FAILED(HttpStatus.BAD_REQUEST, "400", "이메일 인증에 실패하였습니다."),
-    EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "403", "토큰 정보가 만료되었습니다. 로그인이 필요합니다."),
-    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "401", "토큰이 존재하지 않습니다."),
-    VERIFICATION_FAILED(HttpStatus.UNAUTHORIZED, "401", "인증에 실패했습니다."),
+	/* AUTH */
+	NO_JWT_TOKEN("401", "로그인 정보가 존재하지 않습니다. 다시 로그인해 주세요."),
+	NOT_AUTHORIZED_TOKEN("403", "접근 권한이 없습니다."),
+	INVALID_REFRESH_TOKEN("401", "로그인 정보가 유효하지 않습니다."),
+	INVALID_TOKEN_TYPE("401", "로그인 정보 형식이 올바르지 않습니다."),
+	INVALID_TOKEN_STRUCTURE("401", "로그인 정보가 올바르지 않습니다."),
+	MODIFIED_TOKEN_DETECTED("401", "로그인 정보가 변경되었습니다."),
+	EMAIL_VERIFICATION_FAILED("400", "이메일 인증에 실패하였습니다."),
+	EXPIRED_REFRESH_TOKEN("403", "토큰 정보가 만료되었습니다. 로그인이 필요합니다."),
+	EXPIRED_TOKEN("401", "토큰이 존재하지 않습니다."),
+	VERIFICATION_FAILED("401", "인증에 실패했습니다."),
 
-    /* MEMBER */
-    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "404", "등록되지 않은 회원입니다."),
-    FILE_NOT_EXIST(HttpStatus.NOT_FOUND, "404", "파일이 존재하지 않습니다."),
-    SEIZED_TOKEN_DETECTED(HttpStatus.FORBIDDEN, "403", "토큰 정보가 잘못되었습니다."),
-    EMAIL_DUPLICATION(HttpStatus.BAD_REQUEST, "400", "이미 가입된 이메일 입니다."),
-    USERNAME_DUPLICATION(HttpStatus.BAD_REQUEST, "400", "이미 존재하는 닉네임 입니다."),
+	/* MEMBER */
+	MEMBER_NOT_FOUND("404", "등록되지 않은 회원입니다."),
+	FILE_NOT_EXIST("404", "파일이 존재하지 않습니다."),
+	SEIZED_TOKEN_DETECTED("403", "토큰 정보가 잘못되었습니다."),
+	EMAIL_DUPLICATION("400", "이미 가입된 이메일 입니다."),
+	USERNAME_DUPLICATION("400", "이미 존재하는 닉네임 입니다."),
 
-    /* VOTE */
-    VOTE_ALREADY_DONE(HttpStatus.BAD_REQUEST, "400", "이미 투표에 참가하셨습니다."),
-    VOTE_NOT_FOUND(HttpStatus.NOT_FOUND, "404", "투표 정보가 존재하지 않습니다."),
+	/* VOTE */
+	VOTE_ALREADY_DONE("400", "이미 투표에 참가하셨습니다."),
+	VOTE_NOT_FOUND("404", "투표 정보가 존재하지 않습니다."),
 
-    /* LIKES */
-    LIKES_NOT_FOUND(HttpStatus.NOT_FOUND, "404", "좋아요 정보가 존재하지 않습니다."),
-    LIKES_ALREADY_EXISTS(HttpStatus.NOT_FOUND, "404", "이미 좋아요 정보가 있습니다."),
+	/* LIKES */
+	LIKES_NOT_FOUND("404", "좋아요 정보가 존재하지 않습니다."),
+	LIKES_ALREADY_EXISTS("404", "이미 좋아요 정보가 있습니다."),
 
-    /* VALIDATION */
-    INVALID_REQUEST(HttpStatus.BAD_REQUEST, "400", "유효하지 않은 입력값 입니다."),
+	/* VALIDATION */
+	INVALID_REQUEST("400", "유효하지 않은 입력값 입니다."),
 
-    /* UNEXPECTED */
-    UNEXPECTED_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "500", "예상치 못한 에러가 발생하였습니다.");
+	/* UNEXPECTED */
+	UNEXPECTED_EXCEPTION("500", "예상치 못한 에러가 발생하였습니다.");
 
-    private final HttpStatus status;
-    private final String code;
-    private final String message;
+	private final String code;
+	private final String message;
 
-    ErrorCode(HttpStatus status, String code, String message) {
-        this.status = status;
-        this.code = code;
-        this.message = message;
-    }
+	ErrorCode(String code, String message) {
+		this.code = code;
+		this.message = message;
+	}
 
-    public <T> ResponseEntity<Object> toResponse(@Nullable T data) {
-        return new ResponseEntity<>(ResResult.builder()
-                .code(this.getCode())
-                .message(this.getMessage())
-                .data(data)
-                .build(), this.status);
-    }
+	public <T> ResResult<Object> toResponse(@Nullable T data) {
+		return ResResult.builder()
+			.code(this.getCode())
+			.message(this.getMessage())
+			.data(data)
+			.build();
+	}
 }

--- a/src/main/java/dnd/donworry/domain/constants/ResResult.java
+++ b/src/main/java/dnd/donworry/domain/constants/ResResult.java
@@ -1,24 +1,31 @@
 package dnd.donworry.domain.constants;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
 @Builder
 @Getter
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class ResResult <T>{
+public class ResResult<T> {
 
-    private String code;
-    private String message;
-    private T data;
+	@Schema(description = "응답 코드", example = "200")
+	private String code;
 
-    @Override
-    public String toString() {
-        return "ResResult{" +
-                ", code='" + code +'\'' +
-                ", message='" + message +'\'' +
-                ", data=" +data +
-                '}';
-    }
+	@Schema(description = "응답 메시지", example = "{API 요청}에 성공했습니다.")
+	private String message;
+
+	@Schema(description = "응답 데이터")
+	private T data;
+
+	@Override
+	public String toString() {
+		return "ResResult{" +
+			", code='" + code + '\'' +
+			", message='" + message + '\'' +
+			", data=" + data +
+			'}';
+	}
 }

--- a/src/main/java/dnd/donworry/domain/constants/ResponseCode.java
+++ b/src/main/java/dnd/donworry/domain/constants/ResponseCode.java
@@ -1,7 +1,6 @@
 package dnd.donworry.domain.constants;
 
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 
 import jakarta.annotation.Nullable;
 import lombok.Getter;
@@ -12,7 +11,8 @@ import lombok.ToString;
 public enum ResponseCode {
 	/*TEST*/
 	TEST_SAVED(HttpStatus.OK, "200", "테스트 결과 저장에 성공했습니다."),
-	TEST_SUCCESS(HttpStatus.OK, "200", "테스트 결과 조회에 성공했습니다."),
+	TEST_SUCCESS(HttpStatus.OK, "200", "테스트 결과 생성에 성공했습니다."),
+	TEST_FIND_SUCCESS(HttpStatus.OK, "200", "테스트 결과 조회에 성공했습니다."),
 
 	/*AUTH*/
 	MEMBER_SAVE(HttpStatus.OK, "200", "회원가입에 성공했습니다."),
@@ -52,11 +52,11 @@ public enum ResponseCode {
 		this.message = message;
 	}
 
-	public <T> ResponseEntity<Object> toResponse(@Nullable T data) {
-		return new ResponseEntity<>(ResResult.builder()
-			.code(this.getCode())
-			.message(this.getMessage())
+	public <T> ResResult<T> toResponse(@Nullable T data) {
+		return ResResult.<T>builder()
+			.code(this.code)
+			.message(this.message)
 			.data(data)
-			.build(), this.getHttpStatus());
+			.build();
 	}
 }

--- a/src/main/java/dnd/donworry/domain/constants/ResponseCode.java
+++ b/src/main/java/dnd/donworry/domain/constants/ResponseCode.java
@@ -1,7 +1,5 @@
 package dnd.donworry.domain.constants;
 
-import org.springframework.http.HttpStatus;
-
 import jakarta.annotation.Nullable;
 import lombok.Getter;
 import lombok.ToString;
@@ -10,44 +8,41 @@ import lombok.ToString;
 @ToString
 public enum ResponseCode {
 	/*TEST*/
-	TEST_SAVED(HttpStatus.OK, "200", "테스트 결과 저장에 성공했습니다."),
-	TEST_SUCCESS(HttpStatus.OK, "200", "테스트 결과 생성에 성공했습니다."),
-	TEST_FIND_SUCCESS(HttpStatus.OK, "200", "테스트 결과 조회에 성공했습니다."),
+	TEST_SAVED("200", "테스트 결과 저장에 성공했습니다."),
+	TEST_SUCCESS("200", "테스트 결과 생성에 성공했습니다."),
+	TEST_FIND_SUCCESS("200", "테스트 결과 조회에 성공했습니다."),
 
 	/*AUTH*/
-	MEMBER_SAVE(HttpStatus.OK, "200", "회원가입에 성공했습니다."),
-	MEMBER_LOGIN(HttpStatus.OK, "200", "로그인에 성공했습니다"),
-	MEMBER_LOGOUT(HttpStatus.OK, "200", "로그아웃에 성공했습니다."),
-	VERIFICATION_SUCCESS(HttpStatus.OK, "200", "인증에 성공했습니다."),
+	MEMBER_SAVE("200", "회원가입에 성공했습니다."),
+	MEMBER_LOGIN("200", "로그인에 성공했습니다"),
+	MEMBER_LOGOUT("200", "로그아웃에 성공했습니다."),
+	VERIFICATION_SUCCESS("200", "인증에 성공했습니다."),
 
 	/* MEMBER */
-	MEMBER_DETAIL(HttpStatus.OK, "200", "회원정보 불러오기에 성공했습니다."),
-	MEMBER_UPDATE(HttpStatus.OK, "200", "회원정보 수정에 성공했습니다."),
-	MEMBER_DELETE(HttpStatus.OK, "200", "회원정보 삭제에 성공했습니다."),
-	MEMBER_EXISTS(HttpStatus.OK, "200", "회원존재 여부 조회에 성공했습니다."),
-	AVATAR_UPLOAD(HttpStatus.OK, "200", "이미지 업로드에 성공했습니다."),
-	AVATAR_DELETE(HttpStatus.OK, "200", "이미지 삭제에 성공했습니다."),
+	MEMBER_DETAIL("200", "회원정보 불러오기에 성공했습니다."),
+	MEMBER_UPDATE("200", "회원정보 수정에 성공했습니다."),
+	MEMBER_DELETE("200", "회원정보 삭제에 성공했습니다."),
+	MEMBER_EXISTS("200", "회원존재 여부 조회에 성공했습니다."),
+	AVATAR_UPLOAD("200", "이미지 업로드에 성공했습니다."),
+	AVATAR_DELETE("200", "이미지 삭제에 성공했습니다."),
 
 	/* VOTE */
-	VOTING_SUCCESS(HttpStatus.OK, "200", "투표 생성에 성공했습니다."),
-	VOTING_UPDATE(HttpStatus.OK, "200", "투표 수정에 성공했습니다."),
-	VOTING_DELETE(HttpStatus.OK, "200", "투표 취소에 성공했습니다."),
+	VOTING_SUCCESS("200", "투표 생성에 성공했습니다."),
+	VOTING_UPDATE("200", "투표 수정에 성공했습니다."),
+	VOTING_DELETE("200", "투표 취소에 성공했습니다."),
 
 	/* LIKES */
-	LIKES_ADD(HttpStatus.OK, "200", "좋아요 추가에 성공했습니다."),
-	LIKES_CANCEL(HttpStatus.OK, "200", "좋아요 취소에 성공했습니다."),
+	LIKES_ADD("200", "좋아요 추가에 성공했습니다."),
+	LIKES_CANCEL("200", "좋아요 취소에 성공했습니다."),
 
 	/* SEARCH */
-	SEARCH_SUCCESS(HttpStatus.OK, "200", "검색에 성공했습니다.");
-
-	private final HttpStatus httpStatus;
+	SEARCH_SUCCESS("200", "검색에 성공했습니다.");
 
 	private final String code;
 
 	private final String message;
 
-	ResponseCode(HttpStatus httpStatus, String code, String message) {
-		this.httpStatus = httpStatus;
+	ResponseCode(String code, String message) {
 		this.code = code;
 		this.message = message;
 	}

--- a/src/main/java/dnd/donworry/domain/constants/ResponseCode.java
+++ b/src/main/java/dnd/donworry/domain/constants/ResponseCode.java
@@ -1,61 +1,62 @@
 package dnd.donworry.domain.constants;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
 import jakarta.annotation.Nullable;
 import lombok.Getter;
 import lombok.ToString;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 
 @Getter
 @ToString
 public enum ResponseCode {
-    /*TEST*/
-    TEST_CREATED(HttpStatus.CREATED, "200", "테스트 결과 저장에 성공했습니다."),
+	/*TEST*/
+	TEST_SAVED(HttpStatus.OK, "200", "테스트 결과 저장에 성공했습니다."),
+	TEST_SUCCESS(HttpStatus.OK, "200", "테스트 결과 조회에 성공했습니다."),
 
-    /*AUTH*/
-    MEMBER_SAVE(HttpStatus.CREATED, "200", "회원가입에 성공했습니다."),
-    MEMBER_LOGIN(HttpStatus.OK, "200", "로그인에 성공했습니다"),
-    MEMBER_LOGOUT(HttpStatus.OK, "200", "로그아웃에 성공했습니다."),
-    VERIFICATION_SUCCESS(HttpStatus.OK, "200", "인증에 성공했습니다."),
+	/*AUTH*/
+	MEMBER_SAVE(HttpStatus.OK, "200", "회원가입에 성공했습니다."),
+	MEMBER_LOGIN(HttpStatus.OK, "200", "로그인에 성공했습니다"),
+	MEMBER_LOGOUT(HttpStatus.OK, "200", "로그아웃에 성공했습니다."),
+	VERIFICATION_SUCCESS(HttpStatus.OK, "200", "인증에 성공했습니다."),
 
-    /* MEMBER */
-    MEMBER_DETAIL(HttpStatus.OK, "200", "회원정보 불러오기에 성공했습니다."),
-    MEMBER_UPDATE(HttpStatus.OK, "200", "회원정보 수정에 성공했습니다."),
-    MEMBER_DELETE(HttpStatus.OK, "200", "회원정보 삭제에 성공했습니다."),
-    MEMBER_EXISTS(HttpStatus.OK, "200", "회원존재 여부 조회에 성공했습니다."),
-    AVATAR_UPLOAD(HttpStatus.OK, "200", "이미지 업로드에 성공했습니다."),
-    AVATAR_DELETE(HttpStatus.OK, "200", "이미지 삭제에 성공했습니다."),
+	/* MEMBER */
+	MEMBER_DETAIL(HttpStatus.OK, "200", "회원정보 불러오기에 성공했습니다."),
+	MEMBER_UPDATE(HttpStatus.OK, "200", "회원정보 수정에 성공했습니다."),
+	MEMBER_DELETE(HttpStatus.OK, "200", "회원정보 삭제에 성공했습니다."),
+	MEMBER_EXISTS(HttpStatus.OK, "200", "회원존재 여부 조회에 성공했습니다."),
+	AVATAR_UPLOAD(HttpStatus.OK, "200", "이미지 업로드에 성공했습니다."),
+	AVATAR_DELETE(HttpStatus.OK, "200", "이미지 삭제에 성공했습니다."),
 
-    /* VOTE */
-    VOTING_SUCCESS(HttpStatus.CREATED, "200", "투표 생성에 성공했습니다."),
-    VOTING_UPDATE(HttpStatus.OK, "200", "투표 수정에 성공했습니다."),
-    VOTING_DELETE(HttpStatus.OK, "200", "투표 취소에 성공했습니다."),
+	/* VOTE */
+	VOTING_SUCCESS(HttpStatus.OK, "200", "투표 생성에 성공했습니다."),
+	VOTING_UPDATE(HttpStatus.OK, "200", "투표 수정에 성공했습니다."),
+	VOTING_DELETE(HttpStatus.OK, "200", "투표 취소에 성공했습니다."),
 
-    /* LIKES */
-    LIKES_ADD(HttpStatus.CREATED, "200", "좋아요 추가에 성공했습니다."),
-    LIKES_CANCEL(HttpStatus.OK, "200", "좋아요 취소에 성공했습니다."),
+	/* LIKES */
+	LIKES_ADD(HttpStatus.OK, "200", "좋아요 추가에 성공했습니다."),
+	LIKES_CANCEL(HttpStatus.OK, "200", "좋아요 취소에 성공했습니다."),
 
-    /* SEARCH */
-    SEARCH_SUCCESS(HttpStatus.OK, "200", "검색에 성공했습니다.");
+	/* SEARCH */
+	SEARCH_SUCCESS(HttpStatus.OK, "200", "검색에 성공했습니다.");
 
-    private final HttpStatus httpStatus;
+	private final HttpStatus httpStatus;
 
-    private final String code;
+	private final String code;
 
-    private final String message;
+	private final String message;
 
+	ResponseCode(HttpStatus httpStatus, String code, String message) {
+		this.httpStatus = httpStatus;
+		this.code = code;
+		this.message = message;
+	}
 
-    ResponseCode(HttpStatus httpStatus, String code, String message) {
-        this.httpStatus = httpStatus;
-        this.code = code;
-        this.message = message;
-    }
-
-    public <T> ResponseEntity<Object> toResponse(@Nullable T data) {
-        return new ResponseEntity<>(ResResult.builder()
-                .code(this.getCode())
-                .message(this.getMessage())
-                .data(data)
-                .build(), this.getHttpStatus());
-    }
+	public <T> ResponseEntity<Object> toResponse(@Nullable T data) {
+		return new ResponseEntity<>(ResResult.builder()
+			.code(this.getCode())
+			.message(this.getMessage())
+			.data(data)
+			.build(), this.getHttpStatus());
+	}
 }

--- a/src/main/java/dnd/donworry/domain/constants/ResponseCode.java
+++ b/src/main/java/dnd/donworry/domain/constants/ResponseCode.java
@@ -10,10 +10,10 @@ import org.springframework.http.ResponseEntity;
 @ToString
 public enum ResponseCode {
     /*TEST*/
-    TEST_CREATED(HttpStatus.CREATED, "201", "테스트 결과 저장에 성공했습니다."),
+    TEST_CREATED(HttpStatus.CREATED, "200", "테스트 결과 저장에 성공했습니다."),
 
     /*AUTH*/
-    MEMBER_SAVE(HttpStatus.CREATED, "201", "회원가입에 성공했습니다."),
+    MEMBER_SAVE(HttpStatus.CREATED, "200", "회원가입에 성공했습니다."),
     MEMBER_LOGIN(HttpStatus.OK, "200", "로그인에 성공했습니다"),
     MEMBER_LOGOUT(HttpStatus.OK, "200", "로그아웃에 성공했습니다."),
     VERIFICATION_SUCCESS(HttpStatus.OK, "200", "인증에 성공했습니다."),
@@ -27,12 +27,12 @@ public enum ResponseCode {
     AVATAR_DELETE(HttpStatus.OK, "200", "이미지 삭제에 성공했습니다."),
 
     /* VOTE */
-    VOTING_SUCCESS(HttpStatus.CREATED, "201", "투표 생성에 성공했습니다."),
+    VOTING_SUCCESS(HttpStatus.CREATED, "200", "투표 생성에 성공했습니다."),
     VOTING_UPDATE(HttpStatus.OK, "200", "투표 수정에 성공했습니다."),
     VOTING_DELETE(HttpStatus.OK, "200", "투표 취소에 성공했습니다."),
 
     /* LIKES */
-    LIKES_ADD(HttpStatus.CREATED, "201", "좋아요 추가에 성공했습니다."),
+    LIKES_ADD(HttpStatus.CREATED, "200", "좋아요 추가에 성공했습니다."),
     LIKES_CANCEL(HttpStatus.OK, "200", "좋아요 취소에 성공했습니다."),
 
     /* SEARCH */

--- a/src/main/java/dnd/donworry/domain/dto/test/TestRequestDto.java
+++ b/src/main/java/dnd/donworry/domain/dto/test/TestRequestDto.java
@@ -10,8 +10,12 @@ import lombok.NoArgsConstructor;
 @Data
 @Getter
 public class TestRequestDto {
-    private String buddy;
-    private Long trust;
-    private Long love;
-    private Long talk;
+	private String buddy;
+	private Long trust;
+	private Long love;
+	private Long talk;
+
+	public Long[] factorList() {
+		return new Long[] {trust, love, talk};
+	}
 }

--- a/src/main/java/dnd/donworry/domain/dto/test/TestRequestDto.java
+++ b/src/main/java/dnd/donworry/domain/dto/test/TestRequestDto.java
@@ -1,5 +1,6 @@
 package dnd.donworry.domain.dto.test;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.Getter;
@@ -9,10 +10,18 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Data
 @Getter
+@Schema(name = "테스트 결과 API Request")
 public class TestRequestDto {
+	@Schema(description = "상대방 닉네임", example = "JooHyun")
 	private String buddy;
+
+	@Schema(description = "믿음 개수", example = "1")
 	private Long trust;
+
+	@Schema(description = "사랑 개수", example = "2")
 	private Long love;
+
+	@Schema(description = "대화 개수", example = "3")
 	private Long talk;
 
 	public Long[] factorList() {

--- a/src/main/java/dnd/donworry/domain/dto/test/TestResponseDto.java
+++ b/src/main/java/dnd/donworry/domain/dto/test/TestResponseDto.java
@@ -1,33 +1,47 @@
 package dnd.donworry.domain.dto.test;
 
+import java.time.LocalDateTime;
+
 import dnd.donworry.domain.entity.TestResult;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDateTime;
 
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
+@Builder
 public class TestResponseDto {
-    private String buddy;
-    private Long trust;
-    private Long love;
-    private Long talk;
-    private Long temperature;
-    private String imageUrl;
-    private LocalDateTime createdAt;
+	private String buddy;
+	private Long trust;
+	private Long love;
+	private Long talk;
+	private int temperature;
+	private String imageUrl;
+	private LocalDateTime createdAt;
 
-    public static TestResponseDto of(TestResult testResult) {
-        return new TestResponseDto(
-                testResult.getBuddy(),
-                testResult.getTrust(),
-                testResult.getLove(),
-                testResult.getTalk(),
-                testResult.getTemperature(),
-                testResult.getImageUrl(),
-                testResult.getCreatedAt()
-        );
-    }
+	public static TestResponseDto of(TestResult testResult) {
+		return TestResponseDto.builder()
+			.buddy(testResult.getBuddy())
+			.trust(testResult.getTrust())
+			.love(testResult.getLove())
+			.talk(testResult.getTalk())
+			.temperature(testResult.getTemperature())
+			.imageUrl(testResult.getImageUrl())
+			.createdAt(testResult.getCreatedAt())
+			.build();
+	}
+
+	public static TestResponseDto of(TestRequestDto testRequestDto, int temperature, String imageUrl) {
+		return TestResponseDto.builder()
+			.buddy(testRequestDto.getBuddy())
+			.trust(testRequestDto.getTrust())
+			.love(testRequestDto.getLove())
+			.talk(testRequestDto.getTalk())
+			.temperature(temperature)
+			.imageUrl(imageUrl)
+			.createdAt(LocalDateTime.now())
+			.build();
+	}
 }

--- a/src/main/java/dnd/donworry/domain/dto/test/TestResponseDto.java
+++ b/src/main/java/dnd/donworry/domain/dto/test/TestResponseDto.java
@@ -3,6 +3,7 @@ package dnd.donworry.domain.dto.test;
 import java.time.LocalDateTime;
 
 import dnd.donworry.domain.entity.TestResult;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,13 +13,29 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
+@Schema(name = "테스트 결과 API Response")
 public class TestResponseDto {
+
+	@Schema(description = "상대방 닉네임", example = "JooHyun")
 	private String buddy;
+
+	@Schema(description = "믿음 개수", example = "1")
 	private Long trust;
+
+	@Schema(description = "사랑 개수", example = "2")
 	private Long love;
+
+	@Schema(description = "대화 개수", example = "3")
 	private Long talk;
+
+	// TODO: 등급에 따른 실제 온도를 반환하도록 수정
+	@Schema(description = "온도", example = "4")
 	private int temperature;
+
+	@Schema(description = "이미지 URL", example = "https://s3.ap-northeast-2.amazonaws.com/donworry/1.png")
 	private String imageUrl;
+
+	@Schema(description = "생성일", example = "2021-07-01T00:00:00")
 	private LocalDateTime createdAt;
 
 	public static TestResponseDto of(TestResult testResult) {

--- a/src/main/java/dnd/donworry/domain/entity/TestResult.java
+++ b/src/main/java/dnd/donworry/domain/entity/TestResult.java
@@ -5,49 +5,53 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Builder
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class TestResult extends BaseEntity{
-    @Id
-    @GeneratedValue(strategy = jakarta.persistence.GenerationType.IDENTITY)
-    private Long id;
+public class TestResult extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = jakarta.persistence.GenerationType.IDENTITY)
+	private Long id;
 
-    @Column(nullable = false)
-    private String username;
+	@Column(nullable = false)
+	private String username;
 
-    @Column(nullable = false)
-    private String buddy;
+	@Column(nullable = false)
+	private String buddy;
 
-    @Column(nullable = false)
-    private Long trust;
+	@Column(nullable = false)
+	private Long trust;
 
-    @Column(nullable = false)
-    private Long love;
+	@Column(nullable = false)
+	private Long love;
 
-    @Column(nullable = false)
-    private Long talk;
+	@Column(nullable = false)
+	private Long talk;
 
-    @Column(nullable = false)
-    private Long temperature;
+	@Column(nullable = false)
+	private int temperature;
 
-    @Column(nullable = false)
-    private String imageUrl;
+	@Column(nullable = false)
+	private String imageUrl;
 
-    public static TestResult toEntity (String username, TestResponseDto testResponseDto) {
-        return TestResult.builder()
-                .username(username)
-                .buddy(testResponseDto.getBuddy())
-                .trust(testResponseDto.getTrust())
-                .love(testResponseDto.getLove())
-                .talk(testResponseDto.getTalk())
-                .temperature(testResponseDto.getTemperature())
-                .imageUrl(testResponseDto.getImageUrl())
-                .build();
-    }
+	public static TestResult toEntity(String username, TestResponseDto testResponseDto) {
+		return TestResult.builder()
+			.username(username)
+			.buddy(testResponseDto.getBuddy())
+			.trust(testResponseDto.getTrust())
+			.love(testResponseDto.getLove())
+			.talk(testResponseDto.getTalk())
+			.temperature(testResponseDto.getTemperature())
+			.imageUrl(testResponseDto.getImageUrl())
+			.build();
+	}
 
 }

--- a/src/main/java/dnd/donworry/exception/CustomException.java
+++ b/src/main/java/dnd/donworry/exception/CustomException.java
@@ -1,0 +1,23 @@
+package dnd.donworry.exception;
+
+import dnd.donworry.domain.constants.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+
+	private final ErrorCode errorCode;
+
+	public CustomException(ErrorCode errorCode) {
+		super(errorCode.getMessage());
+		this.errorCode = errorCode;
+	}
+
+	@Override
+	public String toString() {
+		return "CustomException{" +
+			"errorCode=" + errorCode +
+			'}';
+	}
+
+}

--- a/src/main/java/dnd/donworry/exception/ExceptionHandleFilter.java
+++ b/src/main/java/dnd/donworry/exception/ExceptionHandleFilter.java
@@ -1,0 +1,48 @@
+package dnd.donworry.exception;
+
+import java.io.IOException;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import dnd.donworry.domain.constants.ErrorCode;
+import dnd.donworry.domain.constants.ResResult;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@Slf4j
+public class ExceptionHandleFilter extends OncePerRequestFilter {
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+		FilterChain filterChain) throws ServletException, IOException {
+		try {
+			filterChain.doFilter(request, response);
+		} catch (CustomException e) {
+			handleCustomException(e, response);
+		}
+	}
+
+	private void handleCustomException(CustomException e, HttpServletResponse response) throws IOException {
+		log.error("CustomException", e);
+		ResResult<?> errorResponse = buildErrorResponse(e);
+		setResponse(response, errorResponse);
+	}
+
+	private ResResult<?> buildErrorResponse(CustomException e) {
+		String errorMessage = e.getErrorCode().getMessage();
+		ErrorCode errorCode = e.getErrorCode();
+		return ResResult.builder().code(errorCode.getCode()).message(errorMessage).build();
+	}
+
+	private void setResponse(HttpServletResponse response, ResResult<?> errorResponse) throws IOException {
+		response.setStatus(Integer.parseInt(errorResponse.getCode()));
+		response.setContentType("application/json");
+		response.setCharacterEncoding("UTF-8");
+		response.getWriter().write(errorResponse.toString());
+	}
+}

--- a/src/main/java/dnd/donworry/exception/GlobalExceptionHandler.java
+++ b/src/main/java/dnd/donworry/exception/GlobalExceptionHandler.java
@@ -1,0 +1,49 @@
+package dnd.donworry.exception;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.context.support.DefaultMessageSourceResolvable;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+
+import dnd.donworry.domain.constants.ErrorCode;
+import dnd.donworry.domain.constants.ResResult;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+	@ExceptionHandler(CustomException.class)
+	protected ResResult<?> handlerCustomException(CustomException e) {
+		log.error("CustomException: " + e.getErrorCode().getMessage());
+		return e.getErrorCode().toResponse(null);
+	}
+
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	protected ResResult<?> handleMethodArgumentNotValid(
+		MethodArgumentNotValidException e, HttpHeaders h, HttpStatus s, WebRequest w
+	) {
+		Map<String, String> validExceptions = e.getBindingResult().getFieldErrors().stream()
+			.collect(Collectors.toMap(
+				FieldError::getField,
+				DefaultMessageSourceResolvable::getDefaultMessage
+			));
+		log.error("Validation Exception: " + validExceptions);
+		return ErrorCode.INVALID_REQUEST.toResponse(validExceptions);
+	}
+
+	@ExceptionHandler(Exception.class)
+	protected ResResult<?> handlerException(Exception e) {
+		log.error("Unexpected_Exception : " + e.getMessage());
+		log.error("Unexpected_Exception : " + Arrays.toString(e.getStackTrace()));
+		return ErrorCode.UNEXPECTED_EXCEPTION.toResponse(null);
+	}
+}

--- a/src/main/java/dnd/donworry/manager/TestManager.java
+++ b/src/main/java/dnd/donworry/manager/TestManager.java
@@ -1,0 +1,56 @@
+package dnd.donworry.manager;
+
+import org.springframework.stereotype.Component;
+
+import dnd.donworry.domain.dto.test.TestRequestDto;
+import dnd.donworry.domain.dto.test.TestResponseDto;
+
+@Component
+public class TestManager {
+
+	public static final String LOW = "low";
+	public static final String MID = "mid";
+	public static final String HIGH = "high";
+
+	public static final int LOW_TEMPERATURE = 1;
+	public static final int MID_TEMPERATURE = 2;
+	public static final int HIGH_TEMPERATURE = 3;
+	public static final int HIGHEST_TEMPERATURE = 4;
+
+	public TestResponseDto makeResult(TestRequestDto testRequestDto) {
+		int temperature = calculateTemperature(testRequestDto);
+		String imageUrl = makeImageUrl(temperature);
+		return TestResponseDto.of(testRequestDto, temperature, imageUrl);
+	}
+
+	// 리팩토링 필요 (상수 -> 변수)
+	private String calculateFactor(Long factor) {
+		return (factor < -1) ? LOW
+			: (factor < 2) ? MID
+			: HIGH;
+	}
+
+	private int calculateTemperature(TestRequestDto testRequestDto) {
+		int low = 0, mid = 0, high = 0;
+
+		for (Long factor : testRequestDto.factorList()) {
+			String factorType = calculateFactor(factor);
+			if (factorType.equals(LOW))
+				low++;
+			else if (factorType.equals(MID))
+				mid++;
+			else
+				high++;
+		}
+
+		return high >= 3 ? LOW_TEMPERATURE
+			: high == 2 ? MID_TEMPERATURE
+			: mid >= 2 || (high == 1 & mid == 1 & low == 1) ? HIGH_TEMPERATURE
+			: HIGHEST_TEMPERATURE;
+	}
+
+	private String makeImageUrl(int temperature) { // url 수정 필요
+		return "https://s3.ap-northeast-2.amazonaws.com/donworry/" + temperature + ".png";
+	}
+
+}

--- a/src/main/java/dnd/donworry/manager/TestManager.java
+++ b/src/main/java/dnd/donworry/manager/TestManager.java
@@ -43,10 +43,10 @@ public class TestManager {
 				high++;
 		}
 
-		return high >= 3 ? LOW_TEMPERATURE
-			: high == 2 ? MID_TEMPERATURE
-			: mid >= 2 || (high == 1 & mid == 1 & low == 1) ? HIGH_TEMPERATURE
-			: HIGHEST_TEMPERATURE;
+		return high >= 3 ? HIGHEST_TEMPERATURE
+			: high == 2 ? HIGH_TEMPERATURE
+			: mid >= 2 || (high == 1 & mid == 1 & low == 1) ? MID_TEMPERATURE
+			: LOW_TEMPERATURE;
 	}
 
 	private String makeImageUrl(int temperature) { // url 수정 필요

--- a/src/main/java/dnd/donworry/service/TestService.java
+++ b/src/main/java/dnd/donworry/service/TestService.java
@@ -1,10 +1,12 @@
 package dnd.donworry.service;
 
-
+import dnd.donworry.domain.dto.test.TestRequestDto;
 import dnd.donworry.domain.dto.test.TestResponseDto;
 
-
 public interface TestService {
-    void saveAfterSignup(String username, TestResponseDto testResponseDto);
+	void save(String username, TestResponseDto testResponseDto);
 
+	TestResponseDto makeResult(String username, TestRequestDto testRequestDto);
+
+	TestResponseDto findResult(Long testResultId);
 }

--- a/src/main/java/dnd/donworry/service/impl/TestServiceImpl.java
+++ b/src/main/java/dnd/donworry/service/impl/TestServiceImpl.java
@@ -2,9 +2,11 @@ package dnd.donworry.service.impl;
 
 import org.springframework.stereotype.Service;
 
+import dnd.donworry.domain.constants.ErrorCode;
 import dnd.donworry.domain.dto.test.TestRequestDto;
 import dnd.donworry.domain.dto.test.TestResponseDto;
 import dnd.donworry.domain.entity.TestResult;
+import dnd.donworry.exception.CustomException;
 import dnd.donworry.manager.TestManager;
 import dnd.donworry.repository.TestResultRepository;
 import dnd.donworry.service.TestService;
@@ -22,14 +24,15 @@ public class TestServiceImpl implements TestService {
 	@Override
 	public TestResponseDto makeResult(String username, TestRequestDto testRequestDto) {
 		TestResponseDto testReponseDto = testManager.makeResult(testRequestDto);
-		if (!username.isEmpty())
+		if (username != null)
 			save(username, testReponseDto);
 		return testReponseDto;
 	}
 
 	@Override
 	public TestResponseDto findResult(Long testResultId) { // 예외처리 필요
-		return testResultRepository.findById(testResultId).map(TestResponseDto::of).orElse(null);
+		return testResultRepository.findById(testResultId).map(TestResponseDto::of).orElseThrow(
+			() -> new CustomException(ErrorCode.TEST_NOT_FOUND));
 	}
 
 	@Transactional

--- a/src/main/java/dnd/donworry/service/impl/TestServiceImpl.java
+++ b/src/main/java/dnd/donworry/service/impl/TestServiceImpl.java
@@ -1,22 +1,40 @@
 package dnd.donworry.service.impl;
 
+import org.springframework.stereotype.Service;
+
+import dnd.donworry.domain.dto.test.TestRequestDto;
 import dnd.donworry.domain.dto.test.TestResponseDto;
 import dnd.donworry.domain.entity.TestResult;
+import dnd.donworry.manager.TestManager;
 import dnd.donworry.repository.TestResultRepository;
 import dnd.donworry.service.TestService;
 import jakarta.transaction.Transactional;
 import lombok.AllArgsConstructor;
-import org.springframework.stereotype.Service;
-
 
 @AllArgsConstructor
 @Service
 public class TestServiceImpl implements TestService {
 
-    private final TestResultRepository testResultRepository;
+	private final TestResultRepository testResultRepository;
+	private final TestManager testManager;
 
-    @Transactional
-    public void saveAfterSignup(String username, TestResponseDto testResponseDto) {
-        testResultRepository.save(TestResult.toEntity(username, testResponseDto));
-    }
+	@Transactional
+	@Override
+	public TestResponseDto makeResult(String username, TestRequestDto testRequestDto) {
+		TestResponseDto testReponseDto = testManager.makeResult(testRequestDto);
+		if (!username.isEmpty())
+			save(username, testReponseDto);
+		return testReponseDto;
+	}
+
+	@Override
+	public TestResponseDto findResult(Long testResultId) { // 예외처리 필요
+		return testResultRepository.findById(testResultId).map(TestResponseDto::of).orElse(null);
+	}
+
+	@Transactional
+	public void save(String username, TestResponseDto testResponseDto) {
+		testResultRepository.save(TestResult.toEntity(username, testResponseDto));
+	}
+
 }

--- a/src/test/java/dnd/donworry/manager/TestManagerTest.java
+++ b/src/test/java/dnd/donworry/manager/TestManagerTest.java
@@ -1,0 +1,35 @@
+package dnd.donworry.manager;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import dnd.donworry.domain.dto.test.TestRequestDto;
+import dnd.donworry.domain.dto.test.TestResponseDto;
+
+@ExtendWith(MockitoExtension.class)
+public class TestManagerTest {
+
+	@InjectMocks
+	private TestManager testManager;
+
+	@Mock
+	private TestRequestDto testRequestDto;
+
+	@Test
+	public void testMakeResult() {
+		// given
+		when(testRequestDto.factorList()).thenReturn(new Long[] {1L, 2L, 3L});
+
+		// when
+		TestResponseDto result = testManager.makeResult(testRequestDto);
+
+		// then
+		assertEquals(3, result.getTemperature());
+	}
+}


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FEAT] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BUGFIX] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [REFACTOR] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [CHORE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [TEST] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [PERFORMANCE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [SET] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [DOCS] 작업_내용을_한_줄로_요약해서_작성 -->

## ✨ 작업 내용

<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->

- 테스트에 관련된 API를 모두 구현했습니다.
- API 상태 코드 중 성공 상태에 대한 종류를 하나로 통일 (200) 하였습니다.
- Swagger에 모든 API에 상황별 Response를 모두 생성합니다. 이를 위해 ResponseEntitu를 반환하던 기존 코드에서 커스텀된 ResResult 클래스를 반환하는 방식으로 변경하였습니다. 성공 Response에서는 따로 content 컬럼을 지정하지 않고 반환 타입에 Dto를 넣으면 됩니다.

## 📚 작업 결과

<!-- 없다면 적지 않으셔도 됩니다. -->
<!-- 사진이 있다면 함께 첨부해 주세요 -->

<img width="1445" alt="image" src="https://github.com/dnd-side-project/dnd-10th-3-backend/assets/81156109/f3b976ed-a635-4bac-a817-f5c62ccd110e">

<img width="1148" alt="image" src="https://github.com/dnd-side-project/dnd-10th-3-backend/assets/81156109/ea6cb6e3-5fa8-4ef7-8ac7-b3bcbecc6e02">


## 🙏 기타 참고 사항

<!-- 없다면 적지 않으셔도 됩니다. -->

회원별 결과 목록 조회 기능은 패키지 구조 오류를 방지하기 위해 회원 관리 기능이 구현됨에 따라 함께 구현할 예정입니다.

## ✅ PR 등록 전 확인 후 체크해 주세요! (x 표시 해 주세요.)

- [x] Assignees를 지정했습니다. (해당 PR 작업한 사람을 태그해 주세요)
- [x] Labels, Milestone을 등록했습니다.
- [x] Development에 PR 내용과 연결된 Issue를 등록했습니다.