### PR TITLE
[FEAT] 투표 생성 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
-
+**/generated
 
 ### STS ###
 .apt_generated

--- a/build.gradle
+++ b/build.gradle
@@ -1,24 +1,24 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.2.2'
-	id 'io.spring.dependency-management' version '1.1.4'
+    id 'java'
+    id 'org.springframework.boot' version '3.2.2'
+    id 'io.spring.dependency-management' version '1.1.4'
 }
 
 group = 'dnd'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	sourceCompatibility = '17'
+    sourceCompatibility = '17'
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
@@ -26,33 +26,53 @@ dependencies {
 //	implementation 'org.springframework.boot:spring-boot-starter-security'
 //	testImplementation 'org.springframework.security:spring-security-test'
 
-	// TEST
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    // TEST
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
-	// SWAGGER
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+    // SWAGGER
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 
-	// DATABASE
-	runtimeOnly 'com.mysql:mysql-connector-j'
+    // DATABASE
+    runtimeOnly 'com.mysql:mysql-connector-j'
 
-	// WEB
-	implementation 'org.springframework.boot:spring-boot-starter-web'
+    // WEB
+    implementation 'org.springframework.boot:spring-boot-starter-web'
 
-	// JPA
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    // JPA
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
-	// LOMBOK
-	compileOnly 'org.projectlombok:lombok'
-	annotationProcessor 'org.projectlombok:lombok'
+    // LOMBOK
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
 
-	// REDIS
-	implementation group: 'org.springframework.data', name: 'spring-data-redis', version: '3.2.2'
+    // REDIS
+    implementation group: 'org.springframework.data', name: 'spring-data-redis', version: '3.2.2'
 
-	// AWS
-	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+    // AWS
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
+    // QUERYDSL
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
+}
+
+def querydslDir = "$buildDir/generated/querydsl"
+
+sourceSets {
+    main.java.srcDirs += [querydslDir]
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.generatedSourceOutputDirectory = file(querydslDir)
+}
+
+clean.doLast {
+    file(querydslDir).deleteDir()
 }

--- a/src/main/java/dnd/donworry/config/QuerydslConfig.java
+++ b/src/main/java/dnd/donworry/config/QuerydslConfig.java
@@ -1,0 +1,22 @@
+package dnd.donworry.config;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+
+@Configuration
+public class QuerydslConfig {
+
+	@Autowired
+	EntityManager em;
+
+	@Bean
+	public JPAQueryFactory jpaQueryFactory() {
+		return new JPAQueryFactory(em);
+	}
+
+}

--- a/src/main/java/dnd/donworry/controller/TestController.java
+++ b/src/main/java/dnd/donworry/controller/TestController.java
@@ -81,7 +81,7 @@ public class TestController {
 			examples = @ExampleObject(value = "{\n  \"code\": \"403\", \n \"message\": \"접근 권한이 없습니다.\"\n}"))),
 		@ApiResponse(responseCode = "401", description = "토큰이 존재하지 않음", content = @Content(
 			mediaType = "application/json",
-			examples = @ExampleObject(value = "{\n  \"code\": \"401\", \n \"message\": \"토큰이 존재하지 않습니다.\"\n}")))
+			examples = @ExampleObject(value = "{\n  \"code\": \"401\", \n \"message\": \"유효한 토큰이 존재하지 않습니다.\"\n}")))
 	})
 	public ResResult<TestResponseDto> findResult(@PathVariable Long resultId) {
 		return ResponseCode.TEST_SUCCESS.toResponse(testService.findResult(resultId));

--- a/src/main/java/dnd/donworry/controller/VoteController.java
+++ b/src/main/java/dnd/donworry/controller/VoteController.java
@@ -14,6 +14,11 @@ import dnd.donworry.domain.constants.ResponseCode;
 import dnd.donworry.domain.dto.vote.VoteRequestDto;
 import dnd.donworry.domain.dto.vote.VoteResponseDto;
 import dnd.donworry.service.VoteService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
@@ -26,6 +31,25 @@ public class VoteController {
 	private final VoteService voteService;
 
 	@PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+	@Operation(summary = "투표 생성", description = "인증된 회원이 투표를 생성합니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "투표 생성 성공"),
+		@ApiResponse(responseCode = "400", description = "투표 생성 실패", content = @Content(
+			mediaType = "application/json",
+			examples = @ExampleObject(value = "{\n  \"code\": \"400\", \n \"message\": \"투표 생성에 실패했습니다.\"\n}"))),
+		@ApiResponse(responseCode = "404", description = "투표 생성 실패", content = @Content(
+			mediaType = "application/json",
+			examples = @ExampleObject(value = "{\n  \"code\": \"404\", \n \"message\": \"입력값이 잘못되었습니다.\"\n}"))),
+		@ApiResponse(responseCode = "403", description = "접근 권한 없음", content = @Content(
+			mediaType = "application/json",
+			examples = @ExampleObject(value = "{\n  \"code\": \"403\", \n \"message\": \"접근 권한이 없습니다.\"\n}"))),
+		@ApiResponse(responseCode = "401", description = "토큰이 존재하지 않음", content = @Content(
+			mediaType = "application/json",
+			examples = @ExampleObject(value = "{\n  \"code\": \"401\", \n \"message\": \"유효한 토큰이 존재하지 않습니다.\"\n}"))),
+		@ApiResponse(responseCode = "500", description = "서버 에러", content = @Content(
+			mediaType = "application/json",
+			examples = @ExampleObject(value = "{\n  \"code\": \"500\", \n \"message\": \"서버에 에러가 발생했습니다.\"\n}")))
+	})
 	public ResResult<VoteResponseDto> create(@RequestPart VoteRequestDto voteRequestDto,
 		@RequestPart List<MultipartFile> images) {
 		String username = "test"; // Authentication.getName()으로 변경

--- a/src/main/java/dnd/donworry/controller/VoteController.java
+++ b/src/main/java/dnd/donworry/controller/VoteController.java
@@ -1,0 +1,35 @@
+package dnd.donworry.controller;
+
+import java.util.List;
+
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import dnd.donworry.domain.constants.ResResult;
+import dnd.donworry.domain.constants.ResponseCode;
+import dnd.donworry.domain.dto.vote.VoteRequestDto;
+import dnd.donworry.domain.dto.vote.VoteResponseDto;
+import dnd.donworry.service.VoteService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/vote")
+@RequiredArgsConstructor
+@Tag(name = "투표 API", description = "투표를 생성, 삭제, 조회, 수정합니다.")
+public class VoteController {
+
+	private final VoteService voteService;
+
+	@PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+	public ResResult<VoteResponseDto> create(@RequestPart VoteRequestDto voteRequestDto,
+		@RequestPart List<MultipartFile> images) {
+		String username = "test"; // Authentication.getName()으로 변경
+		voteRequestDto.mapImages(images);
+		return ResponseCode.VOTE_CREATED.toResponse(voteService.create(username, voteRequestDto));
+	}
+}

--- a/src/main/java/dnd/donworry/core/manager/AWSFileManager.java
+++ b/src/main/java/dnd/donworry/core/manager/AWSFileManager.java
@@ -1,20 +1,24 @@
 package dnd.donworry.core.manager;
 
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.model.ObjectMetadata;
-import com.amazonaws.services.s3.model.PutObjectRequest;
-import dnd.donworry.core.factory.YamlPropertySourceFactory;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import java.io.File;
+import java.io.IOException;
+import java.util.Objects;
+import java.util.UUID;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.Objects;
-import java.util.UUID;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+
+import dnd.donworry.core.factory.YamlPropertySourceFactory;
+import dnd.donworry.domain.constants.ErrorCode;
+import dnd.donworry.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @RequiredArgsConstructor
 @PropertySource(value = {"classpath:application-s3.yml"}, factory = YamlPropertySourceFactory.class)
@@ -22,50 +26,48 @@ import java.util.UUID;
 @Component
 public class AWSFileManager implements FileManager {
 
-    private final AmazonS3 amazonS3;
+	private final AmazonS3 amazonS3;
 
-    @Value(value = "${cloud.aws.s3.bucket}")
-    private String bucket;
+	@Value(value = "${cloud.aws.s3.bucket}")
+	private String bucket;
 
-    @Override
-    public String upload(String path, MultipartFile multipartFile) throws Exception {
+	@Override
+	public String upload(String path, MultipartFile multipartFile) throws Exception {
 
-        ObjectMetadata objectMetadata = metaDataInstance(multipartFile);
-        String fileUrl = makeFileUrl(path, multipartFile);
+		ObjectMetadata objectMetadata = metaDataInstance(multipartFile);
+		String fileUrl = makeFileUrl(path, multipartFile);
 
-        try {
-            amazonS3.putObject(new PutObjectRequest(
-                bucket, fileUrl, multipartFile.getInputStream(), objectMetadata));
-        } catch (IOException e) {
-            throw new Exception("S3 연동 실패"); // 실제 익셉션으로 변경 필요
-        }
-        return getFileLocation(multipartFile.getOriginalFilename()) + fileUrl;
-    }
+		try {
+			amazonS3.putObject(new PutObjectRequest(
+				bucket, fileUrl, multipartFile.getInputStream(), objectMetadata));
+		} catch (IOException e) {
+			throw new CustomException(ErrorCode.IMAGE_UPLOAD_FAIL); // 실제 익셉션으로 변경 필요
+		}
+		return getFileLocation(multipartFile.getOriginalFilename()) + fileUrl;
+	}
 
-    @Override
-    public String getFileLocation(String key) {
-        return amazonS3.getUrl(bucket, key).toString().split("com")[0] + "com" + File.separator;
-    }
+	@Override
+	public String getFileLocation(String key) {
+		return amazonS3.getUrl(bucket, key).toString().split("com")[0] + "com" + File.separator;
+	}
 
-    private String makeFileUrl(String path, MultipartFile multipartFile) {
-        String extension = getExtension(multipartFile);
-        String fileName = UUID.randomUUID() + "." + extension;
-        return path + File.separator + fileName;
-    }
+	private String makeFileUrl(String path, MultipartFile multipartFile) {
+		String extension = getExtension(multipartFile);
+		String fileName = UUID.randomUUID() + "." + extension;
+		return path + File.separator + fileName;
+	}
 
-    private String getExtension(MultipartFile multipartFile) {
-        String fileName = multipartFile.getOriginalFilename();
-        return Objects.requireNonNull(fileName).substring(fileName.lastIndexOf(".") + 1);
-    }
+	private String getExtension(MultipartFile multipartFile) {
+		String fileName = multipartFile.getOriginalFilename();
+		return Objects.requireNonNull(fileName).substring(fileName.lastIndexOf(".") + 1);
+	}
 
+	private ObjectMetadata metaDataInstance(MultipartFile multipartFile) {
+		ObjectMetadata objectMetadata = new ObjectMetadata();
+		objectMetadata.setContentType(multipartFile.getContentType());
+		objectMetadata.setContentLength(multipartFile.getSize());
 
-    private ObjectMetadata metaDataInstance(MultipartFile multipartFile) {
-        ObjectMetadata objectMetadata = new ObjectMetadata();
-        objectMetadata.setContentType(multipartFile.getContentType());
-        objectMetadata.setContentLength(multipartFile.getSize());
-
-        return objectMetadata;
-    }
-
+		return objectMetadata;
+	}
 
 }

--- a/src/main/java/dnd/donworry/domain/constants/ErrorCode.java
+++ b/src/main/java/dnd/donworry/domain/constants/ErrorCode.java
@@ -47,7 +47,8 @@ public enum ErrorCode {
 	INVALID_REQUEST("400", "유효하지 않은 입력값 입니다."),
 
 	/* UNEXPECTED */
-	UNEXPECTED_EXCEPTION("500", "예상치 못한 에러가 발생하였습니다.");
+	UNEXPECTED_EXCEPTION("500", "예상치 못한 에러가 발생하였습니다."),
+	SELECTION_SIZE_UNDER_TWO("400", "선택지는 최소 2개 이상이어야 합니다.");
 
 	private final String code;
 	private final String message;

--- a/src/main/java/dnd/donworry/domain/constants/ErrorCode.java
+++ b/src/main/java/dnd/donworry/domain/constants/ErrorCode.java
@@ -36,6 +36,8 @@ public enum ErrorCode {
 	/* VOTE */
 	VOTE_ALREADY_DONE("400", "이미 투표에 참가하셨습니다."),
 	VOTE_NOT_FOUND("404", "투표 정보가 존재하지 않습니다."),
+	IMAGE_UPLOAD_FAIL("500", "이미지 업로드에 실패하였습니다."),
+	SELECTION_SAVE_FAILED("500", "선택지 생성에 실패하였습니다."),
 
 	/* LIKES */
 	LIKES_NOT_FOUND("404", "좋아요 정보가 존재하지 않습니다."),

--- a/src/main/java/dnd/donworry/domain/constants/ResponseCode.java
+++ b/src/main/java/dnd/donworry/domain/constants/ResponseCode.java
@@ -27,9 +27,9 @@ public enum ResponseCode {
 	AVATAR_DELETE("200", "이미지 삭제에 성공했습니다."),
 
 	/* VOTE */
-	VOTING_SUCCESS("200", "투표 생성에 성공했습니다."),
-	VOTING_UPDATE("200", "투표 수정에 성공했습니다."),
-	VOTING_DELETE("200", "투표 취소에 성공했습니다."),
+	VOTE_CREATED("200", "투표 생성에 성공했습니다."),
+	VOTE_MODIFIED("200", "투표 수정에 성공했습니다."),
+	VOTE_DELETED("200", "투표 취소에 성공했습니다."),
 
 	/* LIKES */
 	LIKES_ADD("200", "좋아요 추가에 성공했습니다."),

--- a/src/main/java/dnd/donworry/domain/dto/selection/SelectionRequestDto.java
+++ b/src/main/java/dnd/donworry/domain/dto/selection/SelectionRequestDto.java
@@ -1,0 +1,22 @@
+package dnd.donworry.domain.dto.selection;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+@Getter
+@Schema(name = "선택지 API Request")
+public class SelectionRequestDto {
+	@Schema(description = "선택지 내용", example = "100만원")
+	private String content;
+
+	@Schema(description = "선택지 이미지", hidden = true)
+	private MultipartFile image;
+}

--- a/src/main/java/dnd/donworry/domain/dto/selection/SelectionResponseDto.java
+++ b/src/main/java/dnd/donworry/domain/dto/selection/SelectionResponseDto.java
@@ -1,0 +1,57 @@
+package dnd.donworry.domain.dto.selection;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import dnd.donworry.domain.entity.Selection;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Schema(name = "투표 API Response")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class SelectionResponseDto {
+
+	@Schema(description = "선택지 ID", example = "1")
+	private Long id;
+
+	@Schema(description = "선택지 내용", example = "100만원")
+	private String content;
+
+	@Schema(description = "선택지 투표 수", example = "0")
+	private int count;
+
+	@Schema(description = "선택지 이미지 경로", example = "https://donworry.s3.ap-northeast-2.amazonaws.com/selection/1")
+	private String imagePath;
+
+	@Schema(description = "선택지 투표 비율", example = "0")
+	private int votePercentage;
+
+	public static SelectionResponseDto of(Selection selection) {
+		if (selection.getOptionImage() != null) {
+			return ofImage(selection);
+		}
+		return SelectionResponseDto.builder()
+			.id(selection.getId())
+			.content(selection.getContent())
+			.count(selection.getCount())
+			.build();
+	}
+
+	public static SelectionResponseDto ofImage(Selection selection) {
+		return SelectionResponseDto.builder()
+			.id(selection.getId())
+			.count(selection.getCount())
+			.imagePath(selection.getOptionImage().getPath())
+			.build();
+	}
+
+	public void setVotePercentage(int voteCount, int totalVoteCount) {
+		this.votePercentage = (int)((double)voteCount / totalVoteCount * 100);
+	}
+}

--- a/src/main/java/dnd/donworry/domain/dto/vote/VoteRequestDto.java
+++ b/src/main/java/dnd/donworry/domain/dto/vote/VoteRequestDto.java
@@ -1,0 +1,38 @@
+package dnd.donworry.domain.dto.vote;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import dnd.donworry.domain.dto.selection.SelectionRequestDto;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+@Getter
+@Schema(name = "투표 API Request")
+public class VoteRequestDto {
+	@Schema(description = "투표 제목", example = "축의금은 얼마가 적당할까요?")
+	private String title;
+
+	@Schema(description = "투표 내용", example = "절친 결혼식에 축의금을 얼마나 주는게 적당할까요?")
+	private String content;
+
+	@Schema(description = "투표 선택지")
+	private List<SelectionRequestDto> selections;
+
+	@Schema(description = "투표 시작일", example = "2021-08-01T00:00:00")
+	private LocalDateTime closeDate;
+
+	public void mapImages(List<MultipartFile> images) {
+		for (int i = 0; i < selections.size(); i++) {
+			selections.get(i).setImage(images.get(i));
+		}
+	}
+}

--- a/src/main/java/dnd/donworry/domain/dto/vote/VoteResponseDto.java
+++ b/src/main/java/dnd/donworry/domain/dto/vote/VoteResponseDto.java
@@ -1,0 +1,74 @@
+package dnd.donworry.domain.dto.vote;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import dnd.donworry.domain.dto.selection.SelectionResponseDto;
+import dnd.donworry.domain.entity.User;
+import dnd.donworry.domain.entity.Vote;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Schema(name = "투표 API Response")
+public class VoteResponseDto {
+
+	@Schema(description = "투표 ID", example = "1")
+	private Long id;
+
+	@Schema(description = "투표 생성자")
+	private User user;
+
+	@Schema(description = "투표 제목", example = "축의금은 얼마가 적당할까요?")
+	private String title;
+
+	@Schema(description = "투표 내용", example = "절친 결혼식에 축의금을 얼마나 주는게 적당할까요?")
+	private String content;
+
+	@Schema(description = "투표 선택지")
+	private List<SelectionResponseDto> selections;
+
+	@Schema(description = "좋아요 개수", example = "0")
+	private int likes;
+
+	@Schema(description = "조회수", example = "0")
+	private int views;
+
+	@Schema(description = "투표자 수", example = "0")
+	private int voters;
+
+	@Schema(description = "투표 상태", example = "false")
+	private boolean status;
+
+	@Schema(description = "투표 마감일", example = "2021-08-01T00:00:00")
+	private LocalDateTime closeDate;
+
+	@Schema(description = "생성일", example = "2021-07-01T00:00:00")
+	private LocalDateTime createdAt;
+
+	@Schema(description = "수정일", example = "2021-07-01T00:00:00")
+	private LocalDateTime updatedAt;
+
+	public static VoteResponseDto of(Vote vote, List<SelectionResponseDto> selections) {
+		return VoteResponseDto.builder()
+			.id(vote.getId())
+			.user(vote.getUser())
+			.title(vote.getTitle())
+			.content(vote.getContent())
+			.selections(selections)
+			.likes(vote.getLikes())
+			.views(vote.getViews())
+			.voters(vote.getVoters())
+			.status(vote.isStatus())
+			.closeDate(vote.getCloseDate())
+			.createdAt(vote.getCreatedAt())
+			.updatedAt(vote.getModifiedAt())
+			.build();
+	}
+}

--- a/src/main/java/dnd/donworry/domain/entity/OptionImage.java
+++ b/src/main/java/dnd/donworry/domain/entity/OptionImage.java
@@ -1,7 +1,16 @@
 package dnd.donworry.domain.entity;
 
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
@@ -9,13 +18,20 @@ import lombok.*;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class OptionImage {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
 
-    @OneToOne
-    private Selection selection;
+	@OneToOne
+	private Selection selection;
 
-    @Column(nullable = false)
-    private String path;
+	@Column(nullable = false)
+	private String path;
+
+	public static OptionImage toEntity(String path, Selection selection) {
+		return OptionImage.builder()
+			.selection(selection)
+			.path(path)
+			.build();
+	}
 }

--- a/src/main/java/dnd/donworry/domain/entity/Selection.java
+++ b/src/main/java/dnd/donworry/domain/entity/Selection.java
@@ -1,7 +1,19 @@
 package dnd.donworry.domain.entity;
 
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
@@ -10,20 +22,38 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Selection {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
 
-    @ManyToOne
-    private Vote vote;
+	@ManyToOne
+	private Vote vote;
 
-    @OneToOne(mappedBy = "selection", optional = true)
-    private OptionImage optionImage;
+	@OneToOne(mappedBy = "selection", cascade = CascadeType.ALL,
+		orphanRemoval = true, fetch = FetchType.EAGER)
+	private OptionImage optionImage;
 
-    @Column(nullable = false)
-    private String content;
+	@Column
+	private String content;
 
-    @Column(nullable = false)
-    private int count = 0;
+	@Column(nullable = false)
+	private int count = 0;
+
+	public static Selection toEntity(String content, Vote vote) {
+		return Selection.builder()
+			.content(content)
+			.vote(vote)
+			.build();
+	}
+
+	public static Selection toEntity(Vote vote) {
+		return Selection.builder()
+			.vote(vote)
+			.build();
+	}
+
+	public void setOptionImage(OptionImage optionImage) {
+		this.optionImage = optionImage;
+	}
 
 }

--- a/src/main/java/dnd/donworry/domain/entity/Vote.java
+++ b/src/main/java/dnd/donworry/domain/entity/Vote.java
@@ -1,36 +1,60 @@
 package dnd.donworry.domain.entity;
 
-import jakarta.persistence.*;
-import lombok.*;
+import java.time.LocalDateTime;
+
+import dnd.donworry.domain.dto.vote.VoteRequestDto;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Vote extends BaseEntity{
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+public class Vote extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
 
-    @ManyToOne
-    private User user;
+	@ManyToOne
+	private User user;
 
-    @Column(nullable = false)
-    private String title;
+	@Column(nullable = false)
+	private String title;
 
-    @Column(nullable = false)
-    private String content;
+	@Column(nullable = false)
+	private String content;
 
-    @Column(nullable = false)
-    private int likes = 0;
+	@Column(nullable = false)
+	private int likes = 0;
 
-    @Column(nullable = false)
-    private int views = 0;
+	@Column(nullable = false)
+	private int views = 0;
 
-    @Column(nullable = false)
-    private int voters = 0;
+	@Column(nullable = false)
+	private int voters = 0;
 
-    @Column(nullable = false)
-    private boolean status = false;
+	@Column(nullable = false)
+	private boolean status = false;
+
+	@Column(nullable = false, updatable = false)
+	private LocalDateTime closeDate;
+
+	public static Vote toEntity(VoteRequestDto voteRequestDto, User user) {
+		return Vote.builder()
+			.user(user)
+			.title(voteRequestDto.getTitle())
+			.content(voteRequestDto.getContent())
+			.closeDate(voteRequestDto.getCloseDate())
+			.build();
+	}
 }

--- a/src/main/java/dnd/donworry/repository/OptionImageRepository.java
+++ b/src/main/java/dnd/donworry/repository/OptionImageRepository.java
@@ -1,0 +1,8 @@
+package dnd.donworry.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import dnd.donworry.domain.entity.OptionImage;
+
+public interface OptionImageRepository extends JpaRepository<OptionImage, Long> {
+}

--- a/src/main/java/dnd/donworry/repository/SelectionRepository.java
+++ b/src/main/java/dnd/donworry/repository/SelectionRepository.java
@@ -1,0 +1,9 @@
+package dnd.donworry.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import dnd.donworry.domain.entity.Selection;
+import dnd.donworry.repository.custom.SelectionRepositoryCustom;
+
+public interface SelectionRepository extends JpaRepository<Selection, Long>, SelectionRepositoryCustom {
+}

--- a/src/main/java/dnd/donworry/repository/Support/Querydsl4RepositorySupport.java
+++ b/src/main/java/dnd/donworry/repository/Support/Querydsl4RepositorySupport.java
@@ -1,0 +1,115 @@
+package dnd.donworry.repository.Support;
+
+import java.util.List;
+import java.util.function.Function;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.support.JpaEntityInformation;
+import org.springframework.data.jpa.repository.support.JpaEntityInformationSupport;
+import org.springframework.data.jpa.repository.support.Querydsl;
+import org.springframework.data.querydsl.SimpleEntityPathResolver;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.Assert;
+
+import com.querydsl.core.types.EntityPath;
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.dsl.PathBuilder;
+import com.querydsl.jpa.impl.JPADeleteClause;
+import com.querydsl.jpa.impl.JPAInsertClause;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.querydsl.jpa.impl.JPAUpdateClause;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.persistence.EntityManager;
+
+@Repository
+public abstract class Querydsl4RepositorySupport {
+	private final Class domainClass;
+	private Querydsl querydsl;
+	private EntityManager entityManager;
+	private JPAQueryFactory queryFactory;
+
+	public Querydsl4RepositorySupport(Class<?> domainClass) {
+		Assert.notNull(domainClass, "Domain class must not be null!");
+		this.domainClass = domainClass;
+	}
+
+	@PostConstruct
+	public void validate() {
+		Assert.notNull(entityManager, "EntityManager must not be null!");
+		Assert.notNull(querydsl, "Querydsl must not be null!");
+		Assert.notNull(queryFactory, "QueryFactory must not be null!");
+	}
+
+	protected JPAQueryFactory getQueryFactory() {
+		return queryFactory;
+	}
+
+	protected Querydsl getQuerydsl() {
+		return querydsl;
+	}
+
+	protected EntityManager getEntityManager() {
+		return entityManager;
+	}
+
+	@Autowired
+	public void setEntityManager(EntityManager entityManager) {
+		Assert.notNull(entityManager, "EntityManager must not be null!");
+
+		JpaEntityInformation entityInformation =
+			JpaEntityInformationSupport.getEntityInformation(domainClass, entityManager);
+		SimpleEntityPathResolver resolver = SimpleEntityPathResolver.INSTANCE;
+		EntityPath path = resolver.createPath(entityInformation.getJavaType());
+
+		this.entityManager = entityManager;
+		this.querydsl = new Querydsl(entityManager, new PathBuilder<>(path.getType(), path.getMetadata()));
+		this.queryFactory = new JPAQueryFactory(entityManager);
+	}
+
+	protected <T> JPAQuery<T> select(Expression<T> expr) {
+		return getQueryFactory().select(expr);
+	}
+
+	protected <T> JPADeleteClause delete(EntityPath<T> from) {
+		return getQueryFactory().delete(from);
+	}
+
+	protected <T> JPAInsertClause insert(EntityPath<T> from) {
+		return getQueryFactory().insert(from);
+	}
+
+	protected <T> JPAUpdateClause update(EntityPath<T> from) {
+		return getQueryFactory().update(from);
+	}
+
+	protected <T> JPAQuery<T> selectFrom(EntityPath<T> from) {
+		return getQueryFactory().selectFrom(from);
+	}
+
+	protected <T> Page<T> applyPagination(Pageable pageable,
+		Function<JPAQueryFactory, JPAQuery> contentQuery) {
+		JPAQuery jpaQuery = contentQuery.apply(getQueryFactory());
+		List<T> content = getFetch(pageable, jpaQuery);
+
+		return PageableExecutionUtils.getPage(content, pageable, jpaQuery::fetchCount);
+	}
+
+	protected <T> Page<T> applyPagination(Pageable pageable,
+		Function<JPAQueryFactory, JPAQuery> contentQuery, Function<JPAQueryFactory,
+		JPAQuery> countQuery) {
+		JPAQuery jpaContentQuery = contentQuery.apply(getQueryFactory());
+		List<T> content = getFetch(pageable, jpaContentQuery);
+		JPAQuery countResult = countQuery.apply(getQueryFactory());
+
+		return PageableExecutionUtils.getPage(content, pageable, countResult::fetchCount);
+	}
+
+	private List getFetch(Pageable pageable, JPAQuery jpaContentQuery) {
+		return getQuerydsl().applyPagination(pageable, jpaContentQuery).fetch();
+	}
+}

--- a/src/main/java/dnd/donworry/repository/VoteRepository.java
+++ b/src/main/java/dnd/donworry/repository/VoteRepository.java
@@ -1,0 +1,8 @@
+package dnd.donworry.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import dnd.donworry.domain.entity.Vote;
+
+public interface VoteRepository extends JpaRepository<Vote, Long> {
+}

--- a/src/main/java/dnd/donworry/repository/custom/SelectionRepositoryCustom.java
+++ b/src/main/java/dnd/donworry/repository/custom/SelectionRepositoryCustom.java
@@ -1,0 +1,10 @@
+package dnd.donworry.repository.custom;
+
+import java.util.List;
+
+import dnd.donworry.domain.entity.Selection;
+
+public interface SelectionRepositoryCustom {
+
+	List<Selection> findByVoteId(Long voteId);
+}

--- a/src/main/java/dnd/donworry/repository/impl/SelectionRepositoryImpl.java
+++ b/src/main/java/dnd/donworry/repository/impl/SelectionRepositoryImpl.java
@@ -1,0 +1,18 @@
+package dnd.donworry.repository.impl;
+
+import static com.querydsl.jpa.JPAExpressions.*;
+import static dnd.donworry.domain.entity.QSelection.*;
+
+import java.util.List;
+
+import dnd.donworry.domain.entity.Selection;
+import dnd.donworry.repository.custom.SelectionRepositoryCustom;
+
+public class SelectionRepositoryImpl implements SelectionRepositoryCustom {
+	@Override
+	public List<Selection> findByVoteId(Long voteId) {
+		return selectFrom(selection)
+			.where(selection.vote.id.eq(voteId))
+			.fetch();
+	}
+}

--- a/src/main/java/dnd/donworry/service/VoteService.java
+++ b/src/main/java/dnd/donworry/service/VoteService.java
@@ -1,0 +1,20 @@
+package dnd.donworry.service;
+
+import java.util.List;
+
+import dnd.donworry.domain.dto.vote.VoteRequestDto;
+import dnd.donworry.domain.dto.vote.VoteResponseDto;
+
+public interface VoteService {
+
+	VoteResponseDto create(String username, VoteRequestDto voteRequestDto);
+
+	void delete(Long postId, String username);
+
+	VoteResponseDto update(Long postId, String username);
+
+	List<VoteResponseDto> findAllVotes(Long postId);
+
+	VoteResponseDto findVote(Long postId, String username);
+
+}

--- a/src/main/java/dnd/donworry/service/impl/TestServiceImpl.java
+++ b/src/main/java/dnd/donworry/service/impl/TestServiceImpl.java
@@ -11,10 +11,10 @@ import dnd.donworry.manager.TestManager;
 import dnd.donworry.repository.TestResultRepository;
 import dnd.donworry.service.TestService;
 import jakarta.transaction.Transactional;
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 
-@AllArgsConstructor
 @Service
+@RequiredArgsConstructor
 public class TestServiceImpl implements TestService {
 
 	private final TestResultRepository testResultRepository;
@@ -30,7 +30,7 @@ public class TestServiceImpl implements TestService {
 	}
 
 	@Override
-	public TestResponseDto findResult(Long testResultId) { // 예외처리 필요
+	public TestResponseDto findResult(Long testResultId) {
 		return testResultRepository.findById(testResultId).map(TestResponseDto::of).orElseThrow(
 			() -> new CustomException(ErrorCode.TEST_NOT_FOUND));
 	}

--- a/src/main/java/dnd/donworry/service/impl/VoteServiceImpl.java
+++ b/src/main/java/dnd/donworry/service/impl/VoteServiceImpl.java
@@ -1,0 +1,102 @@
+package dnd.donworry.service.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import dnd.donworry.core.manager.FileManager;
+import dnd.donworry.domain.constants.ErrorCode;
+import dnd.donworry.domain.dto.selection.SelectionRequestDto;
+import dnd.donworry.domain.dto.selection.SelectionResponseDto;
+import dnd.donworry.domain.dto.vote.VoteRequestDto;
+import dnd.donworry.domain.dto.vote.VoteResponseDto;
+import dnd.donworry.domain.entity.OptionImage;
+import dnd.donworry.domain.entity.Selection;
+import dnd.donworry.domain.entity.User;
+import dnd.donworry.domain.entity.Vote;
+import dnd.donworry.exception.CustomException;
+import dnd.donworry.repository.OptionImageRepository;
+import dnd.donworry.repository.SelectionRepository;
+import dnd.donworry.repository.VoteRepository;
+import dnd.donworry.service.VoteService;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class VoteServiceImpl implements VoteService {
+
+	private final SelectionRepository selectionRepository;
+	private final OptionImageRepository optionImageRepository;
+	private final VoteRepository voteRepository;
+	private final FileManager fileManager;
+
+	@Override
+	public VoteResponseDto create(String username, VoteRequestDto voteRequestDto) {
+		User user = new User(1L, "test", "test", ""); // 실제 유저로 변경
+		Vote vote = voteRepository.save(Vote.toEntity(voteRequestDto, user));
+
+		List<SelectionResponseDto> selectionResponseDtos = saveSelections(voteRequestDto.getSelections(), vote);
+		setVotePercentage(selectionResponseDtos, vote.getVoters());
+
+		return VoteResponseDto.of(vote, selectionResponseDtos);
+	}
+
+	@Override
+	public void delete(Long postId, String username) {
+
+	}
+
+	@Override
+	public VoteResponseDto update(Long postId, String username) {
+		return null;
+	}
+
+	@Override
+	public List<VoteResponseDto> findAllVotes(Long postId) {
+		return null;
+	}
+
+	@Override
+	public VoteResponseDto findVote(Long postId, String username) {
+		return null;
+	}
+
+	private String saveImage(MultipartFile image) {
+		try {
+			return fileManager.upload("Selection", image);
+		} catch (Exception e) {
+			throw new CustomException(ErrorCode.IMAGE_UPLOAD_FAIL);
+		}
+	}
+
+	private List<SelectionResponseDto> saveSelections(List<SelectionRequestDto> selections, Vote vote) {
+		List<SelectionResponseDto> selectionResponseDtos = new ArrayList<>();
+		selections.forEach(s -> {
+			Selection selection =
+				s.getImage() != null
+					? createSelectionWithImage(s, vote)
+					: createSelectionWithoutImage(s, vote);
+			selectionResponseDtos.add(SelectionResponseDto.of(selectionRepository.save(selection)));
+		});
+		return selectionResponseDtos;
+	}
+
+	private Selection createSelectionWithImage(SelectionRequestDto selectionRequestDto, Vote vote) {
+		Selection selection = Selection.toEntity(vote);
+		String imagePath = saveImage(selectionRequestDto.getImage());
+		OptionImage optionImage = OptionImage.toEntity(imagePath, selection);
+		selection.setOptionImage(optionImage);
+		optionImageRepository.save(optionImage);
+		return selection;
+	}
+
+	private Selection createSelectionWithoutImage(SelectionRequestDto selectionRequestDto, Vote vote) {
+		return Selection.toEntity(selectionRequestDto.getContent(), vote);
+	}
+
+	private void setVotePercentage(List<SelectionResponseDto> selectionResponseDtos, int totalCount) {
+		selectionResponseDtos.forEach(s -> s.setVotePercentage(s.getCount(), totalCount));
+	}
+}

--- a/src/main/java/dnd/donworry/service/impl/VoteServiceImpl.java
+++ b/src/main/java/dnd/donworry/service/impl/VoteServiceImpl.java
@@ -34,6 +34,11 @@ public class VoteServiceImpl implements VoteService {
 
 	@Override
 	public VoteResponseDto create(String username, VoteRequestDto voteRequestDto) {
+
+		if (voteRequestDto.getSelections().size() < 2) {
+			throw new CustomException(ErrorCode.SELECTION_SIZE_UNDER_TWO);
+		}
+
 		User user = new User(1L, "test", "test", ""); // 실제 유저로 변경
 		Vote vote = voteRepository.save(Vote.toEntity(voteRequestDto, user));
 

--- a/src/test/java/dnd/donworry/service/impl/VoteServiceImplTest.java
+++ b/src/test/java/dnd/donworry/service/impl/VoteServiceImplTest.java
@@ -1,0 +1,97 @@
+package dnd.donworry.service.impl;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+
+import dnd.donworry.core.manager.FileManager;
+import dnd.donworry.domain.dto.selection.SelectionRequestDto;
+import dnd.donworry.domain.dto.vote.VoteRequestDto;
+import dnd.donworry.domain.entity.Selection;
+import dnd.donworry.domain.entity.User;
+import dnd.donworry.domain.entity.Vote;
+import dnd.donworry.exception.CustomException;
+import dnd.donworry.repository.OptionImageRepository;
+import dnd.donworry.repository.SelectionRepository;
+import dnd.donworry.repository.VoteRepository;
+import jakarta.transaction.Transactional;
+
+@ExtendWith(MockitoExtension.class)
+class VoteServiceImplTest {
+
+	@Mock
+	OptionImageRepository optionImageRepository;
+	@Mock
+	private VoteRepository voteRepository;
+	@Mock
+	private SelectionRepository selectionRepository;
+	@Mock
+	private FileManager fileManager;
+
+	@InjectMocks
+	private VoteServiceImpl voteServiceImpl;
+
+	@Test
+	@DisplayName("투표는 최소 2개의 선택지를 가져야 한다.")
+	@Transactional
+	void create_under_two_selections() {
+		// Given
+		VoteRequestDto voteRequestDto = new VoteRequestDto();
+		voteRequestDto.setSelections(List.of(new SelectionRequestDto("test1", null)));
+
+		// When
+
+		// Then
+		assertThrows(CustomException.class, () -> voteServiceImpl.create("test", voteRequestDto));
+	}
+
+	@Test
+	@DisplayName("이미지가 없는 투표 생성이 가능하다.")
+	@Transactional
+	void create_over_two_selections_with_content() {
+		// Given
+		VoteRequestDto voteRequestDto = new VoteRequestDto();
+		voteRequestDto.setSelections(
+			List.of(new SelectionRequestDto("test1", null), new SelectionRequestDto("test2", null)));
+		User user = new User(1L, "test", "test", "");
+
+		// When
+		when(voteRepository.save(any())).thenReturn(Vote.toEntity(voteRequestDto, user));
+		when(selectionRepository.save(any())).thenReturn(
+			new Selection(1L, Vote.toEntity(voteRequestDto, user), null, "testContent", 0));
+
+		// Then
+		assertDoesNotThrow(() -> voteServiceImpl.create("test", voteRequestDto));
+	}
+
+	@Test
+	@DisplayName("이미지가 있는 투표 생성이 가능하다.")
+	@Transactional
+	void create_over_two_selections_with_image() throws Exception {
+		// Given
+		VoteRequestDto voteRequestDto = new VoteRequestDto();
+		voteRequestDto.setSelections(
+			List.of(new SelectionRequestDto(null, new MockMultipartFile("test1", new byte[] {})),
+				new SelectionRequestDto(null, new MockMultipartFile("test2", new byte[] {}))));
+		User user = new User(1L, "test", "test", "");
+
+		// When
+		when(voteRepository.save(any())).thenReturn(Vote.toEntity(voteRequestDto, user));
+		when(selectionRepository.save(any())).thenReturn(
+			new Selection(1L, Vote.toEntity(voteRequestDto, user), null, "testContent", 0));
+		when(fileManager.upload(anyString(), any())).thenReturn("test");
+
+		// Then
+		assertDoesNotThrow(() -> voteServiceImpl.create("test", voteRequestDto));
+	}
+}


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FEAT] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BUGFIX] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [REFACTOR] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [CHORE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [TEST] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [PERFORMANCE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [SET] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [DOCS] 작업_내용을_한_줄로_요약해서_작성 -->

## ✨ 작업 내용

<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->

#### QueryDSL 세팅
JPQL을 더 쉽게 다루기 위한 라이브러리인 QueryDSL을 구성했습니다.
스프링부트 3.2.x 버전에 맞춰 QueryDSL 5.0 버전으로 구성했으며 main/generated 안에 직관적으로 QClass 파일이 저장되도록 하였습니다.

#### 투표 생성 API 개발
인증된 회원이 투표를 생성하는 API를 개발했습니다.

투표에는 선택지가 있으며 선택지는 두 가지 종류가 있습니다.
1. 이미지 선택지
2. 문구 선택지

이미지가 포함된 선택지는 자동으로 이미지 선택지로 생성되며 투표 테이블과 별개의 테이블에 저장됩니다.
이 때, 이미지는 S3에 업로드되지만 이미지 테이블에 별도로 저장도 이루어집니다.

문구 선택지는 단순한 문구로 이루어진 선택지로 이미지가 포함되지 않습니다.

두 선택지 모두 참여율이라는 필드를 포함하는데 이 투표율을 계산하는 방법은 (선택지 투표 수/ 해당 투표 전체 투표 수) 이며 정수입니다.


## 📚 작업 결과

<!-- 없다면 적지 않으셔도 됩니다. -->
<!-- 사진이 있다면 함께 첨부해 주세요 -->

![image](https://github.com/dnd-side-project/dnd-10th-3-backend/assets/81156109/8df643c1-f701-4fbb-ab21-dcfb3540e211)


## 🙏 기타 참고 사항

<!-- 없다면 적지 않으셔도 됩니다. -->

## ✅ PR 등록 전 확인 후 체크해 주세요! (x 표시 해 주세요.)

- [x] Assignees를 지정했습니다. (해당 PR 작업한 사람을 태그해 주세요)
- [x] Labels, Milestone을 등록했습니다.
- [x] Development에 PR 내용과 연결된 Issue를 등록했습니다.