### PR TITLE
[FEAT] 댓글 공감 API 개발

### DIFF
--- a/src/main/java/dnd/donworry/controller/CommentController.java
+++ b/src/main/java/dnd/donworry/controller/CommentController.java
@@ -4,6 +4,7 @@ import dnd.donworry.domain.constants.ResResult;
 import dnd.donworry.domain.constants.ResponseCode;
 import dnd.donworry.domain.dto.comment.CommentRequestDto;
 import dnd.donworry.domain.dto.comment.CommentResponseDto;
+import dnd.donworry.domain.dto.commentLike.CommentLikeResponseDto;
 import dnd.donworry.service.CommentService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -24,7 +25,7 @@ public class CommentController {
     private final CommentService commentService;
 
     @PostMapping("/vote/{voteId}")
-    @Operation(summary = "투표 생성", description = "인증된 회원이 투표를 생성합니다.")
+    @Operation(summary = "댓글 생성", description = "인증된 회원이 댓글을 생성합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "댓글 생성 성공"),
             @ApiResponse(responseCode = "404", description = "댓글 생성 실패", content = @Content(
@@ -47,7 +48,7 @@ public class CommentController {
     }
 
     @PatchMapping("/{commentId}")
-    @Operation(summary = "투표 수정", description = "인증된 회원이 투표를 수정합니다.")
+    @Operation(summary = "댓글 수정", description = "인증된 회원이 댓글을 수정합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "댓글 수정 성공"),
 
@@ -71,7 +72,7 @@ public class CommentController {
     }
 
     @DeleteMapping("/{commentId}")
-    @Operation(summary = "투표 삭제", description = "인증된 회원이 투표를 삭제합니다.")
+    @Operation(summary = "댓글 삭제", description = "인증된 회원이 댓글을 삭제합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "댓글 삭제 성공"),
             @ApiResponse(responseCode = "404", description = "댓글 삭제 실패", content = @Content(
@@ -91,5 +92,30 @@ public class CommentController {
                                          Authentication authentication) {
         commentService.deleteComment(commentId,authentication.getName());
         return ResponseCode.COMMENT_DELETE.toResponse(null);
+    }
+
+    @PostMapping("/{commentId}/likes")
+    @Operation(summary = "공감 생성, 취소 ", description = "인증된 회원이 공감을 생성, 취소합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "공감 성공"),
+            @ApiResponse(responseCode = "404", description = "공감 실패", content = @Content(
+                    mediaType = "application/json",
+                    examples = @ExampleObject(value = "{\n  \"code\": \"404\", \n \"message\": \"입력값이 잘못되었습니다.\"\n}"))),
+            @ApiResponse(responseCode = "403", description = "접근 권한 없음", content = @Content(
+                    mediaType = "application/json",
+                    examples = @ExampleObject(value = "{\n  \"code\": \"403\", \n \"message\": \"접근 권한이 없습니다.\"\n}"))),
+            @ApiResponse(responseCode = "401", description = "토큰이 존재하지 않음", content = @Content(
+                    mediaType = "application/json",
+                    examples = @ExampleObject(value = "{\n  \"code\": \"401\", \n \"message\": \"유효한 토큰이 존재하지 않습니다.\"\n}"))),
+            @ApiResponse(responseCode = "500", description = "서버 에러", content = @Content(
+                    mediaType = "application/json",
+                    examples = @ExampleObject(value = "{\n  \"code\": \"500\", \n \"message\": \"서버에 에러가 발생했습니다.\"\n}")))
+    })
+    ResResult<CommentLikeResponseDto> empathy(@PathVariable(name = "commentId") Long commentId,
+                                           Authentication authentication) {
+        CommentLikeResponseDto empathy = commentService.updateEmpathy(commentId, authentication.getName());
+        return empathy.isStatus() ? ResponseCode.LIKES_ADD.toResponse(empathy)
+                : ResponseCode.LIKES_CANCEL.toResponse(empathy);
+
     }
 }

--- a/src/main/java/dnd/donworry/domain/dto/commentLike/CommentLikeResponseDto.java
+++ b/src/main/java/dnd/donworry/domain/dto/commentLike/CommentLikeResponseDto.java
@@ -1,0 +1,45 @@
+package dnd.donworry.domain.dto.commentLike;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import dnd.donworry.domain.entity.Comment;
+import dnd.donworry.domain.entity.CommentLike;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(name = "공감 API ResponseDto")
+public class CommentLikeResponseDto {
+    @Schema(description = "댓글 ID", example = "1")
+    private Long commentId;
+
+    @Schema(description = "댓글 내용", example = "축의금 내지 말고 밥만 먹고 오세요")
+    private String content;
+
+    @Schema(description = "생성일", example = "2024-03-03T03:03:03")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "수정일", example = "2024-03-04T03:03:03")
+    private LocalDateTime modifiedAt;
+
+    @Schema(description = "댓글 좋아요 개수", example = "21")
+    private int likes;
+
+    @Schema(description = "댓글 좋아요 상태", example = "false")
+    private boolean status;
+
+    public static CommentLikeResponseDto of(Comment comment, CommentLike commentLike) {
+        return CommentLikeResponseDto.builder()
+                .commentId(comment.getId())
+                .content(comment.getContent())
+                .likes(comment.getLikes())
+                .createdAt(commentLike.getCreatedAt())
+                .modifiedAt(commentLike.getModifiedAt())
+                .status(commentLike.isStatus())
+                .build();
+    }
+}

--- a/src/main/java/dnd/donworry/domain/entity/Comment.java
+++ b/src/main/java/dnd/donworry/domain/entity/Comment.java
@@ -41,4 +41,8 @@ public class Comment extends BaseEntity {
             this.content = content;
         }
     }
+
+    public void updateLike(boolean status) {
+        this.likes += status ? 1 : -1;
+    }
 }

--- a/src/main/java/dnd/donworry/domain/entity/CommentLike.java
+++ b/src/main/java/dnd/donworry/domain/entity/CommentLike.java
@@ -13,16 +13,26 @@ public class CommentLike extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-
     private Long id;
 
     @ManyToOne
     private Comment comment;
 
-
     @ManyToOne
     private User user;
 
     @Column(nullable = false)
-    private boolean status = true;
+    private boolean status = false;
+
+    public static CommentLike toEntity(User user, Comment comment, boolean status) {
+        return CommentLike.builder()
+                .comment(comment)
+                .user(user)
+                .status(status)
+                .build();
+    }
+
+    public void updateStatus() {
+        this.status = !this.status;
+    }
 }

--- a/src/main/java/dnd/donworry/repository/CommentLikeRepository.java
+++ b/src/main/java/dnd/donworry/repository/CommentLikeRepository.java
@@ -1,0 +1,10 @@
+package dnd.donworry.repository;
+
+import dnd.donworry.domain.entity.CommentLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> {
+    Optional<CommentLike> findByCommentIdAndUserEmail(Long commentId, String userEmail);
+}

--- a/src/main/java/dnd/donworry/service/CommentService.java
+++ b/src/main/java/dnd/donworry/service/CommentService.java
@@ -2,6 +2,7 @@ package dnd.donworry.service;
 
 import dnd.donworry.domain.dto.comment.CommentRequestDto;
 import dnd.donworry.domain.dto.comment.CommentResponseDto;
+import dnd.donworry.domain.dto.commentLike.CommentLikeResponseDto;
 
 public interface CommentService {
 
@@ -10,4 +11,6 @@ public interface CommentService {
     CommentResponseDto updateComment(CommentRequestDto commentRequestDto, Long commentId, String email);
 
     void deleteComment(Long commentId, String email);
+
+    CommentLikeResponseDto updateEmpathy(Long commentId, String email);
 }

--- a/src/main/java/dnd/donworry/service/impl/CommentServiceImpl.java
+++ b/src/main/java/dnd/donworry/service/impl/CommentServiceImpl.java
@@ -3,10 +3,13 @@ package dnd.donworry.service.impl;
 import dnd.donworry.domain.constants.ErrorCode;
 import dnd.donworry.domain.dto.comment.CommentRequestDto;
 import dnd.donworry.domain.dto.comment.CommentResponseDto;
+import dnd.donworry.domain.dto.commentLike.CommentLikeResponseDto;
 import dnd.donworry.domain.entity.Comment;
+import dnd.donworry.domain.entity.CommentLike;
 import dnd.donworry.domain.entity.User;
 import dnd.donworry.domain.entity.Vote;
 import dnd.donworry.exception.CustomException;
+import dnd.donworry.repository.CommentLikeRepository;
 import dnd.donworry.repository.CommentRepository;
 import dnd.donworry.repository.UserRepository;
 import dnd.donworry.repository.VoteRepository;
@@ -14,6 +17,8 @@ import dnd.donworry.service.CommentService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -24,6 +29,8 @@ public class CommentServiceImpl implements CommentService {
     private final UserRepository userRepository;
 
     private final VoteRepository voteRepository;
+
+    private final CommentLikeRepository commentLikeRepository;
 
     @Transactional
     @Override
@@ -54,6 +61,32 @@ public class CommentServiceImpl implements CommentService {
         commentRepository.delete(comment);
     }
 
+    public CommentLikeResponseDto updateEmpathy(Long commentId, String email) {
+        Comment comment = findComment(commentId);
+        User user = findUser(email);
+        Optional<CommentLike> findCommentLike = commentLikeRepository.findByCommentIdAndUserEmail(comment.getId(), user.getEmail());
+
+        CommentLike commentLike = findCommentLike.orElseGet(() -> CommentLike.toEntity(user, comment, false));
+
+        savedCommentLike(commentLike);
+
+        savedComment(comment, commentLike);
+
+        return CommentLikeResponseDto.of(comment, commentLike);
+    }
+
+    private void savedCommentLike(CommentLike commentLike) {
+        commentLike.updateStatus();
+        commentLikeRepository.save(commentLike);
+    }
+    private void savedComment(Comment comment, CommentLike commentLike) {
+        comment.updateLike(commentLike.isStatus());
+        commentRepository.save(comment);
+    }
+
+
+
+
     private Comment validateUserAndComment(Long commentId, String email) {
         User user = findUser(email);
         Comment comment = findComment(commentId);
@@ -64,15 +97,13 @@ public class CommentServiceImpl implements CommentService {
     }
 
     private Comment findComment(Long commentId) {
-        Comment comment = commentRepository.findById(commentId)
+        return commentRepository.findById(commentId)
                 .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUNT));
-        return comment;
     }
 
     private User findUser(String email) {
-        User user = userRepository.findUserByEmail(email)
+        return  userRepository.findUserByEmail(email)
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
-        return user;
     }
 
     private Vote findVote(Long voteId) {


### PR DESCRIPTION

<img width="1231" alt="스크린샷 2024-02-17 오전 4 07 08" src="https://github.com/dnd-side-project/dnd-10th-3-backend/assets/118791679/72721b67-c424-4111-b9db-0b5681486224">
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FEAT] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BUGFIX] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [REFACTOR] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [CHORE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [TEST] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [PERFORMANCE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [SET] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [DOCS] 작업_내용을_한_줄로_요약해서_작성 -->

## ✨ 작업 내용
특정 댓글에 대해 사용자가 공감을 누르지 않은 상태이면 상태값을 true로 변경하고 comment의 likes를 1증가 시킵니다.
사용자가 공감을 누른 상태라면 상태값을 false로 변경하고 comment의 likes를 1감소 시킵니다.
댓글 공감 완료와 댓글 공감 취소가 상태값에 따라 다른 message를 반환하게 하였습니다.

댓글 공감에 대해 테스트를 진행하였습니다.

댓글 공감에 대한 Swagger 작성을 하였습니다.

기존에 문구가 수정되지 않은 ApiResponse에 대한 수정을 하였습니다.
<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->

## 📚 작업 결과
![스크린샷 2024-02-17 오전 4 06 43](https://github.com/dnd-side-project/dnd-10th-3-backend/assets/118791679/a89f961c-d8dc-4196-aed3-eef2abd7eb65)

<!-- 없다면 적지 않으셔도 됩니다. -->
<!-- 사진이 있다면 함께 첨부해 주세요 -->

## 🙏 기타 참고 사항

<!-- 없다면 적지 않으셔도 됩니다. -->

## ✅ PR 등록 전 확인 후 체크해 주세요! (x 표시 해 주세요.)

- [x] Assignees를 지정했습니다. (해당 PR 작업한 사람을 태그해 주세요)
- [x] Labels, Milestone을 등록했습니다.
- [x] Development에 PR 내용과 연결된 Issue를 등록했습니다.