### PR TITLE
[FEAT] 유저투표 API 구현

### DIFF
--- a/src/main/java/dnd/donworry/controller/UserVoteController.java
+++ b/src/main/java/dnd/donworry/controller/UserVoteController.java
@@ -1,0 +1,31 @@
+package dnd.donworry.controller;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import dnd.donworry.domain.constants.ResResult;
+import dnd.donworry.domain.constants.ResponseCode;
+import dnd.donworry.service.UserVoteService;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/userVote")
+@Tag(name = "유저 투표 API", description = "유저의 투표를 관리합니다.")
+public class UserVoteController {
+	private final UserVoteService userVoteService;
+
+	@PostMapping("/voteId/{voteId}/selectionId/{selectionId}")
+	public ResResult<?> attend(@PathVariable("voteId") Long voteId, @PathVariable("selectionId") Long selectionId,
+		@Parameter(hidden = true) Authentication authentication) {
+		userVoteService.attend(authentication.getName(), voteId, selectionId);
+		return ResponseCode.USER_VOTE_ATTEND.toResponse(null);
+	}
+}

--- a/src/main/java/dnd/donworry/controller/VoteController.java
+++ b/src/main/java/dnd/donworry/controller/VoteController.java
@@ -101,7 +101,25 @@ public class VoteController {
 			mediaType = "application/json",
 			examples = @ExampleObject(value = "{\n  \"code\": \"500\", \n \"message\": \"서버에 에러가 발생했습니다.\"\n}")))
 	})
-	public ResResult<List<VoteResponseDto>> findAllVotes() {
-		return ResponseCode.VOTE_FOUND.toResponse(voteService.findAllVotes());
+	public ResResult<List<VoteResponseDto>> findAllVotes(
+		@Parameter(hidden = true) Authentication authentication) {
+		return ResponseCode.VOTE_FOUND.toResponse(
+			voteService.findAllVotes(authentication != null ? authentication.getName() : null));
+	}
+
+	@GetMapping("/mine")
+	@Operation(summary = "내 투표 조회", description = "내가 생성한 투표를 조회합니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "투표 조회 성공"),
+		@ApiResponse(responseCode = "400", description = "투표 조회 실패", content = @Content(
+			mediaType = "application/json",
+			examples = @ExampleObject(value = "{\n  \"code\": \"400\", \n \"message\": \"투표 조회에 실패했습니다.\"\n}"))),
+		@ApiResponse(responseCode = "500", description = "서버 에러", content = @Content(
+			mediaType = "application/json",
+			examples = @ExampleObject(value = "{\n  \"code\": \"500\", \n \"message\": \"서버에 에러가 발생했습니다.\"\n}")))
+	})
+	public ResResult<List<VoteResponseDto>> findMyVotes(
+		@Parameter(hidden = true) Authentication authentication) {
+		return ResponseCode.VOTE_FOUND.toResponse(voteService.findMyVotes(authentication.getName()));
 	}
 }

--- a/src/main/java/dnd/donworry/domain/constants/ErrorCode.java
+++ b/src/main/java/dnd/donworry/domain/constants/ErrorCode.java
@@ -56,7 +56,7 @@ public enum ErrorCode {
 	AGE_NOT_FOUND("400", "나이 정보가 존재하지 않습니다."),
 	GENDER_NOT_FOUND("400", "성별 정보가 존재하지 않습니다."),
 	MEMBER_MISSMATCH("403", "회원 정보가 일치하지 않습니다."),
-	;
+	SELECTION_NOT_FOUND("404", "해당 선택지가 존재하지 않습니다.");
 
 	private final String code;
 	private final String message;

--- a/src/main/java/dnd/donworry/domain/constants/ResponseCode.java
+++ b/src/main/java/dnd/donworry/domain/constants/ResponseCode.java
@@ -45,6 +45,7 @@ public enum ResponseCode {
 	/* SEARCH */
 	SEARCH_SUCCESS("200", "검색에 성공했습니다."),
 	VOTE_FOUND("200", "투표 조회에 성공했습니다."),
+	USER_VOTE_ATTEND("200", "유저 투표에 성공했습니다."),
 	;
 
 	private final String code;

--- a/src/main/java/dnd/donworry/domain/dto/userVote/UserVoteRequestDto.java
+++ b/src/main/java/dnd/donworry/domain/dto/userVote/UserVoteRequestDto.java
@@ -1,0 +1,17 @@
+package dnd.donworry.domain.dto.userVote;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+@Getter
+@Slf4j
+public class UserVoteRequestDto {
+	private Long userId;
+	private Long selectionId;
+}

--- a/src/main/java/dnd/donworry/domain/dto/vote/VoteResponseDto.java
+++ b/src/main/java/dnd/donworry/domain/dto/vote/VoteResponseDto.java
@@ -58,7 +58,10 @@ public class VoteResponseDto {
 	@Schema(description = "수정일", example = "")
 	private String updatedAt;
 
-	public static VoteResponseDto of(Vote vote, List<SelectionResponseDto> selections) {
+	@Schema(description = "선택한 선택지 ID", example = "1")
+	private Long selected;
+
+	public static VoteResponseDto of(Vote vote, List<SelectionResponseDto> selections, Long selectedId) {
 		return VoteResponseDto.builder()
 			.id(vote.getId())
 			.user(vote.getUser())
@@ -69,6 +72,7 @@ public class VoteResponseDto {
 			.views(vote.getViews())
 			.voters(vote.getVoters())
 			.status(vote.isStatus())
+			.selected(selectedId)
 			.category(vote.getCategory().getName())
 			.closeDate(TimeUtil.toTimeStampString(vote.getCloseDate()))
 			.createdAt(TimeUtil.toTimeStampString(vote.getCreatedAt()))

--- a/src/main/java/dnd/donworry/domain/entity/Selection.java
+++ b/src/main/java/dnd/donworry/domain/entity/Selection.java
@@ -3,7 +3,6 @@ package dnd.donworry.domain.entity;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -29,8 +28,7 @@ public class Selection {
 	@ManyToOne
 	private Vote vote;
 
-	@OneToOne(mappedBy = "selection", cascade = CascadeType.ALL,
-		orphanRemoval = true, fetch = FetchType.EAGER)
+	@OneToOne(mappedBy = "selection", cascade = CascadeType.ALL)
 	private OptionImage optionImage;
 
 	@Column

--- a/src/main/java/dnd/donworry/domain/entity/UserVote.java
+++ b/src/main/java/dnd/donworry/domain/entity/UserVote.java
@@ -1,7 +1,15 @@
 package dnd.donworry.domain.entity;
 
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
@@ -10,16 +18,20 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserVote extends BaseEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
 
-    private Long id;
+	@ManyToOne
+	private User user;
 
+	@ManyToOne
+	private Selection selection;
 
-    @ManyToOne
-    private User user;
-
-    @ManyToOne
-    private Selection selection;
-
+	public static UserVote of(User user, Selection selection) {
+		return UserVote.builder()
+			.user(user)
+			.selection(selection)
+			.build();
+	}
 }

--- a/src/main/java/dnd/donworry/repository/OptionImageRepository.java
+++ b/src/main/java/dnd/donworry/repository/OptionImageRepository.java
@@ -3,6 +3,7 @@ package dnd.donworry.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import dnd.donworry.domain.entity.OptionImage;
+import dnd.donworry.repository.custom.OptionImageRepositoryCustom;
 
-public interface OptionImageRepository extends JpaRepository<OptionImage, Long> {
+public interface OptionImageRepository extends JpaRepository<OptionImage, Long>, OptionImageRepositoryCustom {
 }

--- a/src/main/java/dnd/donworry/repository/UserRepository.java
+++ b/src/main/java/dnd/donworry/repository/UserRepository.java
@@ -11,5 +11,5 @@ public interface UserRepository extends JpaRepository<User, Long>, UserRepositor
 	Optional<User> findUserByEmail(String email);
 
 	Boolean existsByNickname(String nickname);
-	
+
 }

--- a/src/main/java/dnd/donworry/repository/UserVoteRepository.java
+++ b/src/main/java/dnd/donworry/repository/UserVoteRepository.java
@@ -1,0 +1,9 @@
+package dnd.donworry.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import dnd.donworry.domain.entity.UserVote;
+import dnd.donworry.repository.custom.UserVoteRepositoryCustom;
+
+public interface UserVoteRepository extends JpaRepository<UserVote, Long>, UserVoteRepositoryCustom {
+}

--- a/src/main/java/dnd/donworry/repository/VoteRepository.java
+++ b/src/main/java/dnd/donworry/repository/VoteRepository.java
@@ -3,6 +3,7 @@ package dnd.donworry.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import dnd.donworry.domain.entity.Vote;
+import dnd.donworry.repository.custom.VoteRepositoryCustom;
 
-public interface VoteRepository extends JpaRepository<Vote, Long> {
+public interface VoteRepository extends JpaRepository<Vote, Long>, VoteRepositoryCustom {
 }

--- a/src/main/java/dnd/donworry/repository/custom/OptionImageRepositoryCustom.java
+++ b/src/main/java/dnd/donworry/repository/custom/OptionImageRepositoryCustom.java
@@ -1,0 +1,6 @@
+package dnd.donworry.repository.custom;
+
+public interface OptionImageRepositoryCustom {
+
+	void deleteAllByVoteId(Long voteId);
+}

--- a/src/main/java/dnd/donworry/repository/custom/SelectionRepositoryCustom.java
+++ b/src/main/java/dnd/donworry/repository/custom/SelectionRepositoryCustom.java
@@ -9,4 +9,6 @@ public interface SelectionRepositoryCustom {
 	List<Selection> findByVoteId(Long voteId);
 
 	Selection findByIdCustom(Long selectionId);
+
+	void deleteAllByVoteId(Long voteId);
 }

--- a/src/main/java/dnd/donworry/repository/custom/SelectionRepositoryCustom.java
+++ b/src/main/java/dnd/donworry/repository/custom/SelectionRepositoryCustom.java
@@ -7,4 +7,6 @@ import dnd.donworry.domain.entity.Selection;
 public interface SelectionRepositoryCustom {
 
 	List<Selection> findByVoteId(Long voteId);
+
+	Selection findByIdCustom(Long selectionId);
 }

--- a/src/main/java/dnd/donworry/repository/custom/UserRepositoryCustom.java
+++ b/src/main/java/dnd/donworry/repository/custom/UserRepositoryCustom.java
@@ -5,4 +5,5 @@ import dnd.donworry.domain.entity.User;
 public interface UserRepositoryCustom {
 
 	User findByEmailCustom(String email);
+	
 }

--- a/src/main/java/dnd/donworry/repository/custom/UserVoteRepositoryCustom.java
+++ b/src/main/java/dnd/donworry/repository/custom/UserVoteRepositoryCustom.java
@@ -7,4 +7,6 @@ import dnd.donworry.domain.entity.UserVote;
 public interface UserVoteRepositoryCustom {
 
 	Optional<UserVote> findUserVoteByEmailAndVoteId(String email, Long voteId);
+
+	Long findUserSelectionForVote(String email, Long voteId);
 }

--- a/src/main/java/dnd/donworry/repository/custom/UserVoteRepositoryCustom.java
+++ b/src/main/java/dnd/donworry/repository/custom/UserVoteRepositoryCustom.java
@@ -1,0 +1,10 @@
+package dnd.donworry.repository.custom;
+
+import java.util.Optional;
+
+import dnd.donworry.domain.entity.UserVote;
+
+public interface UserVoteRepositoryCustom {
+
+	Optional<UserVote> findUserVoteByEmailAndVoteId(String email, Long voteId);
+}

--- a/src/main/java/dnd/donworry/repository/custom/VoteRepositoryCustom.java
+++ b/src/main/java/dnd/donworry/repository/custom/VoteRepositoryCustom.java
@@ -1,0 +1,10 @@
+package dnd.donworry.repository.custom;
+
+import java.util.List;
+
+import dnd.donworry.domain.entity.Vote;
+
+public interface VoteRepositoryCustom {
+
+	List<Vote> findMyVotes(String email);
+}

--- a/src/main/java/dnd/donworry/repository/impl/OptionImageRepositoryImpl.java
+++ b/src/main/java/dnd/donworry/repository/impl/OptionImageRepositoryImpl.java
@@ -1,0 +1,20 @@
+package dnd.donworry.repository.impl;
+
+import static dnd.donworry.domain.entity.QOptionImage.*;
+
+import dnd.donworry.domain.entity.OptionImage;
+import dnd.donworry.repository.Support.Querydsl4RepositorySupport;
+import dnd.donworry.repository.custom.OptionImageRepositoryCustom;
+
+public class OptionImageRepositoryImpl extends Querydsl4RepositorySupport implements OptionImageRepositoryCustom {
+	public OptionImageRepositoryImpl() {
+		super(OptionImage.class);
+	}
+
+	@Override
+	public void deleteAllByVoteId(Long voteId) {
+		delete(optionImage)
+			.where(optionImage.selection.vote.id.eq(voteId))
+			.execute();
+	}
+}

--- a/src/main/java/dnd/donworry/repository/impl/SelectionRepositoryImpl.java
+++ b/src/main/java/dnd/donworry/repository/impl/SelectionRepositoryImpl.java
@@ -29,4 +29,11 @@ public class SelectionRepositoryImpl extends Querydsl4RepositorySupport implemen
 			.where(selection.id.eq(selectionId))
 			.fetchOne()).orElseThrow(() -> new CustomException(ErrorCode.SELECTION_NOT_FOUND));
 	}
+
+	@Override
+	public void deleteAllByVoteId(Long voteId) {
+		delete(selection)
+			.where(selection.vote.id.eq(voteId))
+			.execute();
+	}
 }

--- a/src/main/java/dnd/donworry/repository/impl/SelectionRepositoryImpl.java
+++ b/src/main/java/dnd/donworry/repository/impl/SelectionRepositoryImpl.java
@@ -3,8 +3,11 @@ package dnd.donworry.repository.impl;
 import static dnd.donworry.domain.entity.QSelection.*;
 
 import java.util.List;
+import java.util.Optional;
 
+import dnd.donworry.domain.constants.ErrorCode;
 import dnd.donworry.domain.entity.Selection;
+import dnd.donworry.exception.CustomException;
 import dnd.donworry.repository.Support.Querydsl4RepositorySupport;
 import dnd.donworry.repository.custom.SelectionRepositoryCustom;
 
@@ -18,5 +21,12 @@ public class SelectionRepositoryImpl extends Querydsl4RepositorySupport implemen
 		return selectFrom(selection)
 			.where(selection.vote.id.eq(voteId))
 			.fetch();
+	}
+
+	@Override
+	public Selection findByIdCustom(Long selectionId) {
+		return Optional.ofNullable(selectFrom(selection)
+			.where(selection.id.eq(selectionId))
+			.fetchOne()).orElseThrow(() -> new CustomException(ErrorCode.SELECTION_NOT_FOUND));
 	}
 }

--- a/src/main/java/dnd/donworry/repository/impl/UserVoteRepositoryImpl.java
+++ b/src/main/java/dnd/donworry/repository/impl/UserVoteRepositoryImpl.java
@@ -22,4 +22,14 @@ public class UserVoteRepositoryImpl extends Querydsl4RepositorySupport implement
 				).fetchOne()
 		);
 	}
+
+	@Override
+	public Long findUserSelectionForVote(String email, Long voteId) {
+		return selectFrom(userVote)
+			.where(userVote.selection.vote.id.eq(voteId)
+				.and(userVote.user.email.eq(email))
+			)
+			.select(userVote.selection.id)
+			.fetchOne();
+	}
 }

--- a/src/main/java/dnd/donworry/repository/impl/UserVoteRepositoryImpl.java
+++ b/src/main/java/dnd/donworry/repository/impl/UserVoteRepositoryImpl.java
@@ -1,0 +1,25 @@
+package dnd.donworry.repository.impl;
+
+import static dnd.donworry.domain.entity.QUserVote.*;
+
+import java.util.Optional;
+
+import dnd.donworry.domain.entity.UserVote;
+import dnd.donworry.repository.Support.Querydsl4RepositorySupport;
+import dnd.donworry.repository.custom.UserVoteRepositoryCustom;
+
+public class UserVoteRepositoryImpl extends Querydsl4RepositorySupport implements UserVoteRepositoryCustom {
+	public UserVoteRepositoryImpl() {
+		super(UserVote.class);
+	}
+
+	@Override
+	public Optional<UserVote> findUserVoteByEmailAndVoteId(String email, Long voteId) {
+		return Optional.ofNullable(
+			selectFrom(userVote)
+				.where(userVote.selection.vote.id.eq(voteId)
+					.and(userVote.user.email.eq(email))
+				).fetchOne()
+		);
+	}
+}

--- a/src/main/java/dnd/donworry/repository/impl/VoteRepositoryImpl.java
+++ b/src/main/java/dnd/donworry/repository/impl/VoteRepositoryImpl.java
@@ -1,0 +1,23 @@
+package dnd.donworry.repository.impl;
+
+import static com.querydsl.jpa.JPAExpressions.*;
+import static dnd.donworry.domain.entity.QVote.*;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
+
+import dnd.donworry.domain.entity.Vote;
+import dnd.donworry.repository.custom.VoteRepositoryCustom;
+
+public class VoteRepositoryImpl extends QuerydslRepositorySupport implements VoteRepositoryCustom {
+
+	public VoteRepositoryImpl() {
+		super(Vote.class);
+	}
+
+	@Override
+	public List<Vote> findMyVotes(String email) {
+		return selectFrom(vote).where(vote.user.email.eq(email)).fetch();
+	}
+}

--- a/src/main/java/dnd/donworry/service/UserVoteService.java
+++ b/src/main/java/dnd/donworry/service/UserVoteService.java
@@ -1,0 +1,7 @@
+package dnd.donworry.service;
+
+public interface UserVoteService {
+
+	void attend(String email, Long voteId, Long selectionId);
+	
+}

--- a/src/main/java/dnd/donworry/service/VoteService.java
+++ b/src/main/java/dnd/donworry/service/VoteService.java
@@ -14,8 +14,8 @@ public interface VoteService {
 
 	VoteResponseDto update(VoteUpdateDto voteUpdateDto, String email);
 
-	List<VoteResponseDto> findAllVotes();
+	List<VoteResponseDto> findAllVotes(String email);
 
-	VoteResponseDto findMyVote(String username);
+	List<VoteResponseDto> findMyVotes(String email);
 
 }

--- a/src/main/java/dnd/donworry/service/impl/UserVoteServiceImpl.java
+++ b/src/main/java/dnd/donworry/service/impl/UserVoteServiceImpl.java
@@ -1,0 +1,34 @@
+package dnd.donworry.service.impl;
+
+import org.springframework.stereotype.Service;
+
+import dnd.donworry.domain.entity.UserVote;
+import dnd.donworry.repository.SelectionRepository;
+import dnd.donworry.repository.UserRepository;
+import dnd.donworry.repository.UserVoteRepository;
+import dnd.donworry.service.UserVoteService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class UserVoteServiceImpl implements UserVoteService {
+
+	private final UserVoteRepository userVoteRepository;
+	private final SelectionRepository selectionRepository;
+	private final UserRepository userRepository;
+
+	@Override
+	public void attend(String email, Long voteId, Long selectionId) {
+		// 이미 참여한 경우 (같은 선택지 -> 취소, 다른 선택지 -> 변경)
+		userVoteRepository.findUserVoteByEmailAndVoteId(email, voteId).ifPresent(userVoteRepository::delete);
+
+		if (selectionId != null) {
+			userVoteRepository.save(
+				UserVote.of(userRepository.findByEmailCustom(email), selectionRepository.findByIdCustom(selectionId)));
+		}
+
+	}
+
+}


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FEAT] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BUGFIX] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [REFACTOR] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [CHORE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [TEST] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [PERFORMANCE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [SET] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [DOCS] 작업_내용을_한_줄로_요약해서_작성 -->

## ✨ 작업 내용

<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->

유저 투표 API를 구현했습니다.
이미 참여한 투표라면 기존의 투표정보를 삭제하고 새로운 투표로 대체합니다.

투표 삭제 시 자식 클래스의 데이터를 모두 지우도록 수정했습니다.

회원인 경우 투표 게시글에 내가 투표한 선택지 필드를 추가합니다. 비회원이난 투표하지 않은 경우 null입니다.

내가 등록한 투표를 조회하는 API를 추가 구현했습니다.

## 📚 작업 결과

<!-- 없다면 적지 않으셔도 됩니다. -->
<!-- 사진이 있다면 함께 첨부해 주세요 -->

## 🙏 기타 참고 사항

<!-- 없다면 적지 않으셔도 됩니다. -->

## ✅ PR 등록 전 확인 후 체크해 주세요! (x 표시 해 주세요.)

- [x] Assignees를 지정했습니다. (해당 PR 작업한 사람을 태그해 주세요)
- [x] Labels, Milestone을 등록했습니다.
- [x] Development에 PR 내용과 연결된 Issue를 등록했습니다.