### PR TITLE
[BUGFIX] 회원가입 시 쿠키의 maxAge가 session으로 나오던 버그 수정

### DIFF
--- a/src/main/java/dnd/donworry/service/impl/OauthServiceImpl.java
+++ b/src/main/java/dnd/donworry/service/impl/OauthServiceImpl.java
@@ -52,8 +52,8 @@ public class OauthServiceImpl implements OauthService {
 		refreshToken.ifPresent(refreshTokenRepository::delete);
 		refreshTokenRepository.save(
 			new RefreshToken(tokenDto.getRefreshToken(), email, jwtProvider.getRefreshTokenExpiredTime()));
-		cookieUtil.setCookie(response, REFRESH_TOKEN, tokenDto.getRefreshToken());
-		cookieUtil.setCookie(response, ACCESS_TOKEN, tokenDto.getAccessToken());
+		cookieUtil.setCookie(response, REFRESH_TOKEN, tokenDto.getRefreshToken(),jwtProvider.getRefreshTokenExpiredTime());
+		cookieUtil.setCookie(response, ACCESS_TOKEN, tokenDto.getAccessToken(), jwtProvider.getAccessTokenExpiredTime());
 	}
 
 	@Transactional

--- a/src/main/java/dnd/donworry/util/CookieUtil.java
+++ b/src/main/java/dnd/donworry/util/CookieUtil.java
@@ -3,13 +3,15 @@ package dnd.donworry.util;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
-
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class CookieUtil {
 
+    /*
     public void setCookie(HttpServletResponse response, String key, String value) {
         ResponseCookie responseCookie = ResponseCookie.from(key, value)
                 .httpOnly(true)
@@ -18,7 +20,7 @@ public class CookieUtil {
                 .sameSite("None")
                 .build();
         response.addHeader("Set-Cookie", responseCookie.toString());
-    }
+    }*/
 
     public void setCookie(HttpServletResponse response, String key, String value, Long expiredTime) {
         ResponseCookie responseCookie = ResponseCookie.from(key, value)
@@ -26,7 +28,7 @@ public class CookieUtil {
                 .path("/")
                 .secure(true)
                 .sameSite("None")
-                .maxAge(expiredTime)
+                .maxAge(expiredTime/1000) //현재 expiredTime은 단위가 ms이고 maxAge는 s이다.
                 .build();
         response.addHeader("Set-Cookie", responseCookie.toString());
     }


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FEAT] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BUGFIX] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [REFACTOR] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [CHORE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [TEST] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [PERFORMANCE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [SET] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [DOCS] 작업_내용을_한_줄로_요약해서_작성 -->

## ✨ 작업 내용
토큰 생성 후 기존에 사용하던 setCookie 대신 maxAge 세팅이 있는 setCookie로 변경하였습니다

ms단위인 토큰 유효시간이 s인 maxAge에 작용해 예상치 않던 기간이 나오던 것을 수정하였습니다.
<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->

## 📚 작업 결과

<!-- 없다면 적지 않으셔도 됩니다. -->
<!-- 사진이 있다면 함께 첨부해 주세요 -->

## 🙏 기타 참고 사항

<!-- 없다면 적지 않으셔도 됩니다. -->

## ✅ PR 등록 전 확인 후 체크해 주세요! (x 표시 해 주세요.)

- [x] Assignees를 지정했습니다. (해당 PR 작업한 사람을 태그해 주세요)
- [x] Labels, Milestone을 등록했습니다.
- [x] Development에 PR 내용과 연결된 Issue를 등록했습니다.