### PR TITLE
[PERFORMANCE] 댓글 전체 조회 시 발생하던 N+1 문제 수정

### DIFF
--- a/src/main/java/dnd/donworry/domain/entity/Comment.java
+++ b/src/main/java/dnd/donworry/domain/entity/Comment.java
@@ -5,6 +5,8 @@ import dnd.donworry.domain.dto.comment.CommentRequestDto;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.List;
+
 @Entity
 @Getter
 @Builder
@@ -27,6 +29,10 @@ public class Comment extends BaseEntity {
 
     @Column(nullable = false)
     private int likes = 0;
+
+    @OneToMany(mappedBy = "comment", fetch = FetchType.LAZY)
+    private List<CommentLike> like;
+
 
     public static Comment toEntity(Vote vote, User user, CommentRequestDto commentRequestDto) {
         return Comment.builder()

--- a/src/main/java/dnd/donworry/repository/impl/CommentRepositoryImpl.java
+++ b/src/main/java/dnd/donworry/repository/impl/CommentRepositoryImpl.java
@@ -11,6 +11,7 @@ import org.springframework.data.domain.Pageable;
 import java.util.List;
 
 import static dnd.donworry.domain.entity.QComment.comment;
+import static dnd.donworry.domain.entity.QCommentLike.commentLike;
 
 
 public class CommentRepositoryImpl extends Querydsl4RepositorySupport implements CommentRepositoryCustom {
@@ -39,8 +40,9 @@ public class CommentRepositoryImpl extends Querydsl4RepositorySupport implements
 
     @Override
     public List<Comment> findAllCustom(Long voteId) {
+
         return selectFrom(comment)
-                .leftJoin(comment.vote).fetchJoin()
+                .leftJoin(comment.like, commentLike).fetchJoin()
                 .where(comment.vote.id.eq(voteId))
                 .orderBy(comment.createdAt.asc())
                 .fetch();

--- a/src/main/java/dnd/donworry/service/impl/CommentServiceImpl.java
+++ b/src/main/java/dnd/donworry/service/impl/CommentServiceImpl.java
@@ -76,9 +76,8 @@ public class CommentServiceImpl implements CommentService {
 
         return comments.stream()
                 .map(c -> {
-                    Optional<CommentLike> commentLike = commentLikeRepository.findByCommentId(c.getId());
-                    boolean isStatus = commentLike.isEmpty() || !commentLike.get().isStatus();
-                    return CommentResponseDto.of(c, !isStatus);
+                    boolean isStatus = c.getLike().stream().anyMatch(like -> like.getUser().getEmail().equals(email) && like.isStatus());
+                    return CommentResponseDto.of(c, isStatus);
                 })
                 .collect(Collectors.toList());
     }


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FEAT] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BUGFIX] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [REFACTOR] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [CHORE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [TEST] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [PERFORMANCE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [SET] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [DOCS] 작업_내용을_한_줄로_요약해서_작성 -->

## ✨ 작업 내용
기존 comment id를 기준으로 순회하며 status를 할당했던 로직에서 연관관계 매핑을 통해 N+1 문제를 해결
<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->

## 📚 작업 결과
![스크린샷 2024-03-05 오후 3 10 14](https://github.com/dnd-side-project/dnd-10th-3-backend/assets/118791679/761f5663-996b-4179-b026-497f4b03de2c)

<!-- 없다면 적지 않으셔도 됩니다. -->
<!-- 사진이 있다면 함께 첨부해 주세요 -->

## 🙏 기타 참고 사항

<!-- 없다면 적지 않으셔도 됩니다. -->

## ✅ PR 등록 전 확인 후 체크해 주세요! (x 표시 해 주세요.)

- [x] Assignees를 지정했습니다. (해당 PR 작업한 사람을 태그해 주세요)
- [x] Labels, Milestone을 등록했습니다.
- [x] Development에 PR 내용과 연결된 Issue를 등록했습니다.